### PR TITLE
Preparation for auto-formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,216 @@
+---
+Language:        JavaScript
+# BasedOnStyle:  WebKit
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignEscapedNewlines: Right
+AlignOperands:   DontAlign
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: All
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: WebKit
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: BinPack
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: false
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequiresClause: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RequiresClausePosition: OwnLine
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -13,4 +13,4 @@ do
 clang-format -i $FILE
 done
 
-exit 0
+exit 1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -10,6 +10,7 @@ UPSTREAM_BRANCH=$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
 
 for FILE in $(git diff --cached --name-only $UPSTREAM_BRANCH | grep -E 'resources/runner/.*\.(js|mjs)')
 do
+echo $FILE
 clang-format -i $FILE
 done
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,7 +6,9 @@ then
     exit
 fi
 
-for FILE in $(git diff --cached --name-only | grep -E '.*\.(js|mjs)')
+UPSTREAM_BRANCH=$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
+
+for FILE in $(git diff --cached --name-only $UPSTREAM_BRANCH | grep -E 'resources/runner/.*\.(js|mjs)')
 do
 clang-format -i $FILE
 done

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if ! command -v clang-format &> /dev/null
+then
+    echo "clang_format could not be found"
+    exit
+fi
+
+for FILE in $(git diff --cached --name-only | grep -E '.*\.(js|mjs)')
+do
+clang-format -i $FILE
+done

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -18,9 +18,11 @@ clang-format -i $FILE
 done
 
 if [[ $(git diff --stat) != '' ]]; then
-  echo "# PRE-PUSH HOOK FAILURE ############################"
-  echo "Some JS files were auto-formatted, please re-commit:"
+  echo "######################################################"
+  echo "# Some JS files were auto-formatted, please re-commit:"
+  echo ""
   git --no-pager diff --stat
-  echo "####################################################"
+  echo ""
+  echo "######################################################"
   exit 1
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -8,12 +8,8 @@ fi
 
 UPSTREAM_BRANCH=$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
 
-echo $UPSTREAM_BRANCH
-echo $(git diff --cached --name-only $UPSTREAM_BRANCH)
-
-for FILE in $(git diff --cached --name-only $UPSTREAM_BRANCH | grep -E 'resources/.*\.(js|mjs)')
+for FILE in $(git diff --cached --name-only $UPSTREAM_BRANCH | grep -E 'resources/[^/]+\.(js|mjs)')
 do
-echo $FILE
 clang-format -i $FILE
 done
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -8,10 +8,13 @@ fi
 
 UPSTREAM_BRANCH=$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
 
-for FILE in $(git diff --cached --name-only $UPSTREAM_BRANCH | grep -E 'resources/runner/.*\.(js|mjs)')
+for FILE in $(git diff --cached --name-only $UPSTREAM_BRANCH | grep -E 'resources/.*\.(js|mjs)')
 do
 echo $FILE
 clang-format -i $FILE
 done
 
-exit 1
+if [[ $(git diff --stat) != '' ]]; then
+  echo "Some JS files were auto-formatted, please re-commit:"
+  git diff --stat
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -8,6 +8,9 @@ fi
 
 UPSTREAM_BRANCH=$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
 
+echo $UPSTREAM_BRANCH
+echo $(git diff --cached --name-only $UPSTREAM_BRANCH)
+
 for FILE in $(git diff --cached --name-only $UPSTREAM_BRANCH | grep -E 'resources/.*\.(js|mjs)')
 do
 echo $FILE

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -18,6 +18,9 @@ clang-format -i $FILE
 done
 
 if [[ $(git diff --stat) != '' ]]; then
+  echo "# PRE-PUSH HOOK FAILURE ############################"
   echo "Some JS files were auto-formatted, please re-commit:"
-  git --no-pager diff --stat
+  git --no-pager diff --
+  echo "####################################################"
+  exit 1
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -19,5 +19,5 @@ done
 
 if [[ $(git diff --stat) != '' ]]; then
   echo "Some JS files were auto-formatted, please re-commit:"
-  git diff --stat
+  git --no-pager diff --stat
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -12,3 +12,5 @@ for FILE in $(git diff --cached --name-only $UPSTREAM_BRANCH | grep -E 'resource
 do
 clang-format -i $FILE
 done
+
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -20,7 +20,7 @@ done
 if [[ $(git diff --stat) != '' ]]; then
   echo "# PRE-PUSH HOOK FAILURE ############################"
   echo "Some JS files were auto-formatted, please re-commit:"
-  git --no-pager diff --
+  git --no-pager diff --stat
   echo "####################################################"
   exit 1
 fi

--- a/resources/main.js
+++ b/resources/main.js
@@ -1,6 +1,7 @@
 // FIXME(camillobruni): Add base class
 
 
+
 class MainBenchmarkClient {
     displayUnit = 'runs/min';
     iterationCount = 10;

--- a/resources/main.js
+++ b/resources/main.js
@@ -1,5 +1,6 @@
 // FIXME(camillobruni): Add base class
 
+
 class MainBenchmarkClient {
     displayUnit = 'runs/min';
     iterationCount = 10;

--- a/resources/main.js
+++ b/resources/main.js
@@ -1,6 +1,5 @@
 // FIXME(camillobruni): Add base class
 
-
 class MainBenchmarkClient {
     displayUnit = 'runs/min';
     iterationCount = 10;

--- a/resources/main.js
+++ b/resources/main.js
@@ -1,7 +1,5 @@
 // FIXME(camillobruni): Add base class
 
-
-
 class MainBenchmarkClient {
     displayUnit = 'runs/min';
     iterationCount = 10;


### PR DESCRIPTION
- Add clang-format WebKit-based formatting config for JS files
- Add pre-push formatting hook

The .clang-format file was generated by `clang-format --style=WebKit --dump-config resourcea/main.js`
The pre-push hook has to be manually enabled after checking out the repository by running `git config core.hooksPath .githooks`.