### PR TITLE
Remove wait from selenium test

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -30,7 +30,12 @@
         <script src="../resources/benchmark-runner.mjs" type="module"></script>
         <script src="benchmark-runner-tests.mjs" type="module"></script>
         <script type="module">
-            window.mochaResults = mocha.run();
+            const runner = mocha.run();
+            runner.on("end", function () {
+                const event = new Event("complete");
+                window.dispatchEvent(event);
+            });
+            window.mochaResults = runner;
         </script>
     </body>
 </html>

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -73,13 +73,16 @@ async function test() {
     try {
         await driver.get(`http://localhost:${PORT}/tests/index.html`);
         console.log("Waiting for tests to finish");
-        await driver.wait(function () {
-            return driver.executeScript("return window.mochaResults.state === 'stopped'");
-        }, 5000);
+        const stats = await driver.executeAsyncScript(function (callback) {
+            window.addEventListener("complete", function onComplete() {
+                window.removeEventListener("complete", onComplete);
+                callback(window.mochaResults.stats);
+            });
+        });
         console.log("Checking for passed tests");
-        assert(await driver.executeScript("return window.mochaResults.stats.passes") > 0);
+        assert(stats.passes > 0);
         console.log("Checking for failed tests");
-        assert(await driver.executeScript("return window.mochaResults.stats.failures") === 0);
+        assert(stats.failures === 0);
     } finally {
         console.log("Tests complete");
         driver.quit();

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -74,10 +74,7 @@ async function test() {
         await driver.get(`http://localhost:${PORT}/tests/index.html`);
         console.log("Waiting for tests to finish");
         const stats = await driver.executeAsyncScript(function (callback) {
-            window.addEventListener("complete", function onComplete() {
-                window.removeEventListener("complete", onComplete);
-                callback(window.mochaResults.stats);
-            });
+            window.addEventListener("complete", () => callback(window.mochaResults.stats), { once: true });
         });
         console.log("Checking for passed tests");
         assert(stats.passes > 0);

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -76,6 +76,7 @@ async function test() {
         const stats = await driver.executeAsyncScript(function (callback) {
             window.addEventListener("complete", () => callback(window.mochaResults.stats), { once: true });
         });
+        console.log("stats", stats);
         console.log("Checking for passed tests");
         assert(stats.passes > 0);
         console.log("Checking for failed tests");


### PR DESCRIPTION
@bgrins pointed out that we introduced some flakiness in our test by adding a timeout in addition to using the "wait" function from the web driver. 

The approach that I am suggesting here, is to take advantage of the "complete" callback from mocha in the browser, dispatching an even on the window object and listening for that event through "executeAsyncScript" from the web driver, which returns a callback with the stats from Mocha. This gives us a bridge between both scopes and returns the mocha stats results that we need to make the assertions.