### PR TITLE
Use params everywhere

### DIFF
--- a/resources/interactive.mjs
+++ b/resources/interactive.mjs
@@ -115,8 +115,7 @@ class InteractiveBenchmarkRunner extends BenchmarkRunner {
 }
 
 // Expose Suites/BenchmarkRunner for backwards compatibility
-window.Suites = Suites;
-window.BenchmarkRunner = InteractiveBenchmarkRunner;
+globalThis.BenchmarkRunner = InteractiveBenchmarkRunner;
 
 function formatTestName(suiteName, testName) {
     return suiteName + (testName ? `/${testName}` : "");
@@ -197,27 +196,17 @@ function createUIForSuites(suites, onStep, onRunSuites) {
     return control;
 }
 
-const searchParams = new URLSearchParams(window.location.search);
-
-function disableAllSuitesExcept(suiteName) {
-    let foundMatching = false;
-    Suites.forEach((element) => {
-        if (element.name !== suiteName)
-            element.disabled = true;
-        else
-            foundMatching = true;
-    });
-    if (!foundMatching)
-        throw Error(`No matching suite for: "${suiteName}"`);
-}
 
 function startTest() {
-    // FIXME: Use global params here
-    if (searchParams.has("suite"))
-        disableAllSuitesExcept(searchParams.get("suite"));
+    if (params.suites.length > 0) {
+        if (!Suites.enable(params.suites)) {
+            const message = `Suite "${params.suites}" does not exist. No tests to run.`;
+            alert(message);
+            console.error(message, params.suites, "\nValid values:", Suites.map(each => each.name));
+        }
+    }
 
     const interactiveRunner = new window.BenchmarkRunner(Suites, params.iterationCount);
-
     if (!(interactiveRunner instanceof InteractiveBenchmarkRunner)) {
         throw Error("window.BenchmarkRunner must be a subclass of InteractiveBenchmarkRunner");
     }

--- a/resources/interactive.mjs
+++ b/resources/interactive.mjs
@@ -196,13 +196,17 @@ function createUIForSuites(suites, onStep, onRunSuites) {
     return control;
 }
 
-
 function startTest() {
     if (params.suites.length > 0) {
         if (!Suites.enable(params.suites)) {
             const message = `Suite "${params.suites}" does not exist. No tests to run.`;
             alert(message);
-            console.error(message, params.suites, "\nValid values:", Suites.map(each => each.name));
+            console.error(
+                message,
+                params.suites,
+                "\nValid values:",
+                Suites.map((each) => each.name)
+            );
         }
     }
 

--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -6,7 +6,7 @@ import { params } from "./params.mjs";
 
 // FIXME(camillobruni): Add base class
 class MainBenchmarkClient {
-    displayUnit = "runs/min";
+    displayUnit = "score";
     iterationCount = 10;
     stepCount = null;
     suitesCount = null;
@@ -19,51 +19,15 @@ class MainBenchmarkClient {
         window.addEventListener("DOMContentLoaded", () => this.prepareUI());
     }
 
-    // FIXME: Move this method to the tests/suites module.
-    enableOneSuite(suites, suiteToEnable) {
-        suiteToEnable = suiteToEnable.toLowerCase();
-        let found = false;
-        for (let i = 0; i < suites.length; i++) {
-            const currentSuite = suites[i];
-            if (currentSuite.name.toLowerCase() === suiteToEnable) {
-                currentSuite.disabled = false;
-                found = true;
-            } else
-                currentSuite.disabled = true;
-        }
-        return found;
-    }
-
     startBenchmark() {
-        if (location.search.length > 1) {
-            // FIXME: Use URLSearchParams
-            let parts = location.search.substring(1).split("&");
-            for (let i = 0; i < parts.length; i++) {
-                const keyValue = parts[i].split("=");
-                const key = keyValue[0];
-                const value = keyValue[1];
-                switch (key) {
-                    case "unit":
-                        if (value === "ms")
-                            this.displayUnit = "ms";
-                        else
-                            console.error(`Invalid unit: ${value}`);
-                        break;
-                    case "iterationCount":
-                        /* eslint-disable-next-line  no-case-declarations */
-                        const parsedValue = parseInt(value);
-                        if (!isNaN(parsedValue))
-                            this.iterationCount = parsedValue;
-                        else
-                            console.error(`Invalid iteration count: ${value}`);
-                        break;
-                    case "suite":
-                        if (!this.enableOneSuite(Suites, value)) {
-                            alert(`Suite "${value}" does not exist. No tests to run.`);
-                            return false;
-                        }
-                        break;
-                }
+        this.displayUnit = params.unit;
+        this.iterationCount = params.iterationCount;
+        if (params.suites.length > 0) {
+            if (!Suites.enable(params.suites)) {
+                const message = `Suite "${params.suites}" does not exist. No tests to run.`;
+                alert(message);
+                console.error(message, params.suites, "\nValid values:", Suites.map(each => each.name));
+                return false;
             }
         }
 
@@ -121,7 +85,7 @@ class MainBenchmarkClient {
 
         if (this.displayUnit === "ms") {
             document.getElementById("show-summary").style.display = "none";
-            this.showResultDetails();
+            this.showResultsDetails();
         } else
             this.showResultsSummary();
     }
@@ -226,6 +190,9 @@ class MainBenchmarkClient {
         document.querySelectorAll(".start-tests-button").forEach((button) => {
             button.onclick = this._startBenchmarkHandler.bind(this);
         });
+
+        if (params.startAutomatically)
+            this._startBenchmarkHandler();
     }
 
     _popStateHandler(event) {
@@ -309,4 +276,4 @@ const rootStyle = document.documentElement.style;
 rootStyle.setProperty("--viewport-width", `${params.viewport.width}px`);
 rootStyle.setProperty("--viewport-height", `${params.viewport.height}px`);
 
-window.benchmarkClient = new MainBenchmarkClient();
+globalThis.benchmarkClient = new MainBenchmarkClient();

--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -26,7 +26,12 @@ class MainBenchmarkClient {
             if (!Suites.enable(params.suites)) {
                 const message = `Suite "${params.suites}" does not exist. No tests to run.`;
                 alert(message);
-                console.error(message, params.suites, "\nValid values:", Suites.map(each => each.name));
+                console.error(
+                    message,
+                    params.suites,
+                    "\nValid values:",
+                    Suites.map((each) => each.name)
+                );
                 return false;
             }
         }

--- a/resources/params.mjs
+++ b/resources/params.mjs
@@ -1,3 +1,5 @@
+const UNITS = ["ms", "score"];
+
 class Params {
     viewport = {
         width: 800,
@@ -6,6 +8,7 @@ class Params {
     startAutomatically = false;
     iterationCount = 10;
     unit = "ms";
+    suites = [];
 
     constructor(searchParams = undefined) {
         if (searchParams)
@@ -15,19 +18,42 @@ class Params {
     }
 
     _copyFromParams(searchParams) {
-        const viewportParam = searchParams.get("viewport");
-        if (viewportParam) {
+        if (searchParams.has("viewport")) {
+            const viewportParam = searchParams.get("viewport");
             const [width, height] = viewportParam.split("x");
             this.viewport.width = parseInt(width) || this.viewport.width;
             this.viewport.height = parseInt(height) || this.viewport.height;
-            if (this.viewport.width < 800 || this.viewport.height < 600) {
-                throw Error(`Invalid viewport param: ${viewportParam}`);
-            }
+            if (this.viewport.width < 800 || this.viewport.height < 600)
+                throw new Error(`Invalid viewport param: ${viewportParam}`);
+            searchParams.delete("viewport");
         }
         this.startAutomatically = searchParams.has("startAutomatically");
-        this.iterationCount = parseInt(searchParams.get("iterationCount")) || this.iterationCount;
-        if (this.iterationCount <= 1)
-            throw Error(`Invalid iterationCount param: ${this.iterationCount}`);
+        searchParams.delete("startAutomatically");
+        if (searchParams.has("iterationCount")) {
+            this.iterationCount = parseInt(searchParams.get("iterationCount")) || this.iterationCount;
+            if (this.iterationCount <= 1)
+                throw new Error(`Invalid iterationCount param: ${this.iterationCount}`);
+            searchParams.delete("iterationCount");
+        }
+
+        if (searchParams.has("unit")) {
+            this.unit = searchParams.get("unit");
+            if (!UNITS.includes(this.unit))
+                throw new Error(`Invalid unit=${this.unit}. Valid values are ${UNITS}`);
+            searchParams.delete("unit");
+        }
+
+        if (searchParams.has("suite") || searchParams.has("suites")) {
+            const value = searchParams.get("suites") || searchParams.get("suites");
+            this.suites = value.split(",");
+            if (this.suites.length === 0)
+                throw new Error("No suites selected");
+            searchParams.delete("suite");
+            searchParams.delete("suites");
+        }
+        const unused = Array.from(searchParams.keys());
+        if (unused.length > 0)
+            console.error("Got unused search params", unused);
     }
 
     toSearchParams() {
@@ -40,4 +66,11 @@ class Params {
 export const defaultParams = new Params();
 
 const searchParams = new URLSearchParams(window.location.search);
-export const params = new Params(searchParams);
+let maybeCustomParams = defaultParams;
+try {
+    maybeCustomParams = new Params(searchParams);
+} catch (e) {
+    console.error("Invalid URL Param", e, "\nUsing defaults as fallback:", maybeCustomParams);
+    alert(`Invalid URL Param: ${e}`);
+}
+export const params = maybeCustomParams;

--- a/resources/params.mjs
+++ b/resources/params.mjs
@@ -42,9 +42,10 @@ class Params {
                 throw new Error(`Invalid unit=${this.unit}. Valid values are ${UNITS}`);
             searchParams.delete("unit");
         }
-
         if (searchParams.has("suite") || searchParams.has("suites")) {
-            const value = searchParams.get("suites") || searchParams.get("suites");
+            if (searchParams.has("suite") && searchParams.has("suites"))
+                throw new Error("Params 'suite' and 'suites' can not be used together.");
+            const value = searchParams.get("suite") || searchParams.get("suites");
             this.suites = value.split(",");
             if (this.suites.length === 0)
                 throw new Error("No suites selected");

--- a/resources/params.mjs
+++ b/resources/params.mjs
@@ -37,7 +37,7 @@ class Params {
         }
 
         if (searchParams.has("unit")) {
-            this.unit = searchParams.get("unit");
+            this.unit = searchParams.get("unit").toLowerCase();
             if (!UNITS.includes(this.unit))
                 throw new Error(`Invalid unit=${this.unit}. Valid values are ${UNITS}`);
             searchParams.delete("unit");

--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -4,15 +4,14 @@ const numberOfItemsToAdd = 100;
 export const Suites = [];
 
 Suites.enable = function (names) {
-    this.forEach((suite) => {
-        suite.disabled = true;
-    });
     const lowerCaseNames = names.map((each) => each.toLowerCase());
     let found = false;
     this.forEach((suite) => {
         if (lowerCaseNames.includes(suite.name.toLowerCase())) {
             suite.disabled = false;
             found = true;
+        } else {
+            suite.disabled = true;
         }
     });
     return found;
@@ -458,8 +457,3 @@ Suites.push({
         }),
     ],
 });
-
-Object.freeze(Suites);
-
-// Expose Suites for backwards compatibility.
-globalThis.Suites = Suites;

--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -3,11 +3,13 @@ import { BenchmarkTestStep } from "./benchmark-runner.mjs";
 const numberOfItemsToAdd = 100;
 export const Suites = [];
 
-Suites.enable = function(names) {
-    this.forEach(suite => { suite.disabled = true; });
-    const lowerCaseNames = names.map(each => each.toLowerCase());
+Suites.enable = function (names) {
+    this.forEach((suite) => {
+        suite.disabled = true;
+    });
+    const lowerCaseNames = names.map((each) => each.toLowerCase());
     let found = false;
-    this.forEach(suite => {
+    this.forEach((suite) => {
         if (lowerCaseNames.includes(suite.name.toLowerCase())) {
             suite.disabled = false;
             found = true;
@@ -15,7 +17,6 @@ Suites.enable = function(names) {
     });
     return found;
 };
-
 
 Suites.push({
     name: "VanillaJS-TodoMVC",

--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -3,6 +3,20 @@ import { BenchmarkTestStep } from "./benchmark-runner.mjs";
 const numberOfItemsToAdd = 100;
 export const Suites = [];
 
+Suites.enable = function(names) {
+    this.forEach(suite => { suite.disabled = true; });
+    const lowerCaseNames = names.map(each => each.toLowerCase());
+    let found = false;
+    this.forEach(suite => {
+        if (lowerCaseNames.includes(suite.name.toLowerCase())) {
+            suite.disabled = false;
+            found = true;
+        }
+    });
+    return found;
+};
+
+
 Suites.push({
     name: "VanillaJS-TodoMVC",
     url: "todomvc/vanilla-examples/vanillajs/index.html",
@@ -443,3 +457,8 @@ Suites.push({
         }),
     ],
 });
+
+Object.freeze(Suites);
+
+// Expose Suites for backwards compatibility.
+globalThis.Suites = Suites;


### PR DESCRIPTION
- Add support for filtering multiple suites
- Support startAutomatically in the default runner
- Fix displaying detailed results with unit=ms
- More error messages on invalid url-params
- Add Suites.enable function instead of two separate implementations per runner