### PR TITLE
Use more helper methods on PageElement

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -76,20 +76,59 @@ class PageElement {
         this.#node.value = value;
     }
 
-    click() {
-        this.#node.click();
-    }
-
     focus() {
         this.#node.focus();
     }
 
-    dispatchEvent(eventName, options = NATIVE_OPTIONS, eventType = Event) {
+    click() {
+        this.#node.click();
+    }
+
+    mouseMove(clientX = 0, clientY = 0) {
+        this._dispatchMouseEvent("mousemove", clientX, clientY);
+    }
+
+    mouseDown(clientX = 0, clientY = 0) {
+        this._dispatchMouseEvent("mousemove", clientX, clientY);
+    }
+
+    mouseUp(clientX = 0, clientY = 0) {
+        this._dispatchMouseEvent("mouseup", clientX, clientY);
+    }
+
+    _dispatchMouseEvent(eventName, clientX, clientY) {
+        let options = {
+            clientX: clientX,
+            clientY: clientY,
+            bubbles: NATIVE_OPTIONS.bubbles,
+            cancelable: NATIVE_OPTIONS.cancellable,
+        };
+        this._dispatchEvent(eventName, options, MouseEvent);
+    }
+
+    scroll(deltaX = 0, deltaY = 0, clientX = 0, clientY = 0) {
+        let options = {
+            clientX: clientX,
+            clientY: clientY,
+            deltaMode: 0,
+            delta: deltaX,
+            deltaY: deltaY,
+            bubbles: NATIVE_OPTIONS.bubbles,
+            cancelable: NATIVE_OPTIONS.cancellable,
+        };
+        this._dispatchEvent("wheel", options, WheelEvent);
+    }
+
+    dispatchEvent(eventName, options = NATIVE_OPTIONS) {
         if (eventName === "submit")
             // FIXME FireFox doesn't like `new Event('submit')
             this._dispatchSubmitEvent();
         else
-            this.#node.dispatchEvent(new eventType(eventName, options));
+            this._dispatchEvent(eventName, options, Event);
+    }
+
+    _dispatchEvent(eventName, options = NATIVE_OPTIONS, eventType = Event) {
+        this.#node.dispatchEvent(new eventType(eventName, options));
     }
 
     _dispatchSubmitEvent() {

--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -332,51 +332,26 @@ Suites.push({
             const cursor = page.querySelector(".react-stockcharts-crosshair-cursor");
             let x = 150;
             let y = 200;
-            const coords = (i) => ({ clientX: x + i * 10, clientY: y + i * 2, bubbles: true, cancelable: true });
+            const coords = (i) => ({ clientX: x + i * 10, clientY: y + i * 2 });
             for (let i = 0; i < 100; ) {
-                cursor.dispatchEvent("mousedown", coords(i), MouseEvent);
-                for (let j = 10; j--; )
-                    cursor.dispatchEvent("mousemove", coords(++i), MouseEvent);
-                cursor.dispatchEvent("mouseup", coords(i), MouseEvent);
+                let { clientX, clientY } = coords(i);
+                cursor.mouseDown(clientX, clientY);
+                for (let j = 10; j--; ) {
+                    ({ clientX, clientY } = coords(++i));
+                    cursor.mouseMove(clientX, clientY);
+                }
+                ({ clientX, clientY } = coords(++i));
+                cursor.mouseUp(clientX, clientY);
             }
         }),
         new BenchmarkTestStep("ZoomTheChart", (page) => {
             const cursor = page.querySelector(".react-stockcharts-crosshair-cursor");
-            let event = {
-                clientX: 200,
-                clientY: 200,
-                deltaMode: 0,
-                delta: -10,
-                deltaY: -10,
-                bubbles: true,
-                cancelable: true,
-            };
             for (let i = 0; i < 30; i++)
-                cursor.dispatchEvent("wheel", event, WheelEvent);
-
-            event = {
-                clientX: 650,
-                clientY: 200,
-                deltaMode: 0,
-                delta: 10,
-                deltaY: 10,
-                bubbles: true,
-                cancelable: true,
-            };
+                cursor.scroll(-10, -10, 200, 200);
             for (let i = 0; i < 10; i++)
-                cursor.dispatchEvent("wheel", event, WheelEvent);
-
-            event = {
-                clientX: 200,
-                clientY: 200,
-                deltaMode: 0,
-                delta: -10,
-                deltaY: -10,
-                bubbles: true,
-                cancelable: true,
-            };
+                cursor.scroll(10, 10, 650, 200);
             for (let i = 0; i < 10; i++)
-                cursor.dispatchEvent("wheel", event, WheelEvent);
+                cursor.scroll(-10, -10, 200, 200);
         }),
     ],
 });
@@ -395,51 +370,26 @@ Suites.push({
             const cursor = page.querySelector(".react-stockcharts-crosshair-cursor");
             let x = 150;
             let y = 200;
-            const coords = (i) => ({ clientX: x + i * 10, clientY: y + i * 2, bubbles: true, cancelable: true });
+            const coords = (i) => ({ clientX: x + i * 10, clientY: y + i * 2 });
             for (let i = 0; i < 100; ) {
-                cursor.dispatchEvent("mousedown", coords(i), MouseEvent);
-                for (let j = 10; j--; )
-                    cursor.dispatchEvent("mousemove", coords(++i), MouseEvent);
-                cursor.dispatchEvent("mouseup", coords(i), MouseEvent);
+                let { clientX, clientY } = coords(i);
+                cursor.mouseDown(clientX, clientY);
+                for (let j = 10; j--; ) {
+                    ({ clientX, clientY } = coords(++i));
+                    cursor.mouseMove(clientX, clientY);
+                }
+                ({ clientX, clientY } = coords(++i));
+                cursor.mouseUp(clientX, clientY);
             }
         }),
         new BenchmarkTestStep("ZoomTheChart", (page) => {
             const cursor = page.querySelector(".react-stockcharts-crosshair-cursor");
-            let event = {
-                clientX: 200,
-                clientY: 200,
-                deltaMode: 0,
-                delta: -10,
-                deltaY: -10,
-                bubbles: true,
-                cancelable: true,
-            };
             for (let i = 0; i < 30; i++)
-                cursor.dispatchEvent("wheel", event, WheelEvent);
-
-            event = {
-                clientX: 650,
-                clientY: 200,
-                deltaMode: 0,
-                delta: 10,
-                deltaY: 10,
-                bubbles: true,
-                cancelable: true,
-            };
+                cursor.scroll(-10, -10, 200, 200);
             for (let i = 0; i < 10; i++)
-                cursor.dispatchEvent("wheel", event, WheelEvent);
-
-            event = {
-                clientX: 200,
-                clientY: 200,
-                deltaMode: 0,
-                delta: -10,
-                deltaY: -10,
-                bubbles: true,
-                cancelable: true,
-            };
+                cursor.scroll(10, 10, 650, 200);
             for (let i = 0; i < 10; i++)
-                cursor.dispatchEvent("wheel", event, WheelEvent);
+                cursor.scroll(-10, -10, 200, 200);
         }),
     ],
 });

--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -347,11 +347,11 @@ Suites.push({
         new BenchmarkTestStep("ZoomTheChart", (page) => {
             const cursor = page.querySelector(".react-stockcharts-crosshair-cursor");
             for (let i = 0; i < 30; i++)
-                cursor.scroll(-10, -10, 200, 200);
+                cursor.wheel(-10, -10, 200, 200);
             for (let i = 0; i < 10; i++)
-                cursor.scroll(10, 10, 650, 200);
+                cursor.wheel(10, 10, 650, 200);
             for (let i = 0; i < 10; i++)
-                cursor.scroll(-10, -10, 200, 200);
+                cursor.wheel(-10, -10, 200, 200);
         }),
     ],
 });
@@ -385,11 +385,11 @@ Suites.push({
         new BenchmarkTestStep("ZoomTheChart", (page) => {
             const cursor = page.querySelector(".react-stockcharts-crosshair-cursor");
             for (let i = 0; i < 30; i++)
-                cursor.scroll(-10, -10, 200, 200);
+                cursor.wheel(-10, -10, 200, 200);
             for (let i = 0; i < 10; i++)
-                cursor.scroll(10, 10, 650, 200);
+                cursor.wheel(10, 10, 650, 200);
             for (let i = 0; i < 10; i++)
-                cursor.scroll(-10, -10, 200, 200);
+                cursor.wheel(-10, -10, 200, 200);
         }),
     ],
 });


### PR DESCRIPTION
Passing in custom event classes to PageElement might become problematic for custom runners.
Let's use custom helper-methods for now to stay runner independent.

- Add mouseUp, mouseDown, mouseMove and scroll helpers
- Use deltaX instead of just delta for wheel events