### PR TITLE
WIP - use performance.measure api instead of manually tracking with performance.now()

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -230,22 +230,18 @@ export class BenchmarkRunner {
     // This function ought be as simple as possible. Don't even use Promise.
     _runTest(suite, test, page, callback) {
         performance.mark(`${suite.name}.${test.name}-start`);
-        const syncStartTime = performance.now();
         test.run(page);
-        const syncEndTime = performance.now();
         performance.mark(`${suite.name}.${test.name}-sync-end`);
+        const syncTime = performance.measure(`${suite.name}.${test.name}-sync`, `${suite.name}.${test.name}-start`).duration;
 
-        const syncTime = syncEndTime - syncStartTime;
-
-        const asyncStartTime = performance.now();
+        performance.mark(`${suite.name}.${test.name}-async-start`);
         setTimeout(() => {
             // Some browsers don't immediately update the layout for paint.
             // Force the layout here to ensure we're measuring the layout time.
             const height = this._frame.contentDocument.body.getBoundingClientRect().height;
-            const asyncEndTime = performance.now();
-            const asyncTime = asyncEndTime - asyncStartTime;
+            const asyncTime = performance.measure(`${suite.name}.${test.name}-async`, `${suite.name}.${test.name}-async-start`).duration;
+
             this._frame.contentWindow._unusedHeightValue = height; // Prevent dead code elimination.
-            performance.mark(`${suite.name}.${test.name}-async-end`);
             window.requestAnimationFrame(() => {
                 callback(syncTime, asyncTime, height);
             });

--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -231,7 +231,6 @@ export class BenchmarkRunner {
     _runTest(suite, test, page, callback) {
         performance.mark(`${suite.name}.${test.name}-start`);
         test.run(page);
-        performance.mark(`${suite.name}.${test.name}-sync-end`);
         const syncTime = performance.measure(`${suite.name}.${test.name}-sync`, `${suite.name}.${test.name}-start`).duration;
 
         performance.mark(`${suite.name}.${test.name}-async-start`);

--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -230,17 +230,25 @@ export class BenchmarkRunner {
     // This function ought be as simple as possible. Don't even use Promise.
     _runTest(suite, test, page, callback) {
         performance.mark(`${suite.name}.${test.name}-start`);
+        const syncStartTime = performance.now();
         test.run(page);
-        const syncTime = performance.measure(`${suite.name}.${test.name}-sync`, `${suite.name}.${test.name}-start`).duration;
+        const syncEndTime = performance.now();
+        performance.mark(`${suite.name}.${test.name}-sync-end`);
+
+        const syncTime = syncEndTime - syncStartTime;
 
         performance.mark(`${suite.name}.${test.name}-async-start`);
+        const asyncStartTime = performance.now();
         setTimeout(() => {
             // Some browsers don't immediately update the layout for paint.
             // Force the layout here to ensure we're measuring the layout time.
             const height = this._frame.contentDocument.body.getBoundingClientRect().height;
-            const asyncTime = performance.measure(`${suite.name}.${test.name}-async`, `${suite.name}.${test.name}-async-start`).duration;
-
+            const asyncEndTime = performance.now();
+            const asyncTime = asyncEndTime - asyncStartTime;
             this._frame.contentWindow._unusedHeightValue = height; // Prevent dead code elimination.
+            performance.mark(`${suite.name}.${test.name}-async-end`);
+            performance.measure(`${suite.name}.${test.name}-sync`, `${suite.name}.${test.name}-start`, `${suite.name}.${test.name}-sync-end`);
+            performance.measure(`${suite.name}.${test.name}-async`, `${suite.name}.${test.name}-async-start`, `${suite.name}.${test.name}-async-end`);
             window.requestAnimationFrame(() => {
                 callback(syncTime, asyncTime, height);
             });

--- a/tests/benchmark-runner-tests.mjs
+++ b/tests/benchmark-runner-tests.mjs
@@ -211,8 +211,9 @@ describe("BenchmarkRunner", () => {
             it("should write performance marks at the start and end of the test with the correct test name", () => {
                 assert.calledWith(peformanceMarkSpy, "Suite 1.Test 1-start");
                 assert.calledWith(peformanceMarkSpy, "Suite 1.Test 1-sync-end");
+                assert.calledWith(peformanceMarkSpy, "Suite 1.Test 1-async-start");
                 assert.calledWith(peformanceMarkSpy, "Suite 1.Test 1-async-end");
-                assert.calledThrice(peformanceMarkSpy);
+                expect(peformanceMarkSpy.callCount).to.equal(4);
             });
 
             it("should run the test", () => {


### PR DESCRIPTION
This would allow profiler tools to show user timing ranges and makes it easier to focus in on different portions of tests.

@camillobruni what do you think about this? My understanding of this API from https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure is that the `duration` object functionally the same as the existing subtractions using performance.now()