### PR TITLE
Use window.location.hash for navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
                         <button class="start-tests-button">Start Test</button>
                     </div>
                     <div class="button-row">
-                        <a href="#about" >About Speedometer</button>
+                        <a href="#about" >About Speedometer</a>
                     </div>
                 </div>
             </section>
@@ -41,7 +41,7 @@
                 </div>
             </section>
 
-            <section id="summarized-results">
+            <section id="summary">
                 <h1>Score</h1>
                 <div class="gauge">
                     <div class="window"><div class="needle"></div></div>
@@ -52,7 +52,24 @@
                 <div class="buttons">
                     <div class="button-row">
                         <button class="start-tests-button" title="Discard the current results and re-run all tests.">Test Again</button>
-                        <a href="#detailed-results" id="show-details" title="Show detailed results data.">Details</a>
+                        <a class="button" href="#details" id="show-details" title="Show detailed results data.">Details</a>
+                    </div>
+                </div>
+            </section>
+
+            <section id="details">
+                <h1>Detailed Results</h1>
+                <table class="results-table"></table>
+                <table class="results-table"></table>
+                <div class="arithmetic-mean"><label>Arithmetic Mean:</label><span id="results-with-statistics"></span></div>
+                <div class="buttons">
+                    <div class="button-row">
+                        <a class="button" id="download-json" download="speedometer.json" title="Download all result metrics as json string.">Download JSON</a>
+                        <button id="copy-json" title="Copy all result metrics as json string.">Copy JSON</button>
+                    </div>
+                    <div class="button-row">
+                        <button class="start-tests-button" title="Discard the current results and re-run all tests.">Test Again</button>
+                        <a class="button" href="#summary" title="Go back to the simplified summary view.">Summary</a>
                     </div>
                 </div>
             </section>
@@ -90,24 +107,6 @@
                 </div>
             </section>
         </main>
-        
-        <!-- Keep Detailed results outside main -->
-        <section id="detailed-results">
-            <h1>Detailed Results</h1>
-            <table class="results-table"></table>
-            <table class="results-table"></table>
-            <div class="arithmetic-mean"><label>Arithmetic Mean:</label><span id="results-with-statistics"></span></div>
-            <div class="buttons">
-                <div class="button-row">
-                    <a class="button" id="download-json" download="speedometer.json" title="Download all result metrics as json string.">Download JSON</a>
-                    <button id="copy-json" title="Copy all result metrics as json string.">Copy JSON</button>
-                </div>
-                <div class="button-row">
-                    <button class="start-tests-button" title="Discard the current results and re-run all tests.">Test Again</button>
-                    <button id="show-summary" title="Go back to the simplified summary view.">Summary</button>
-                </div>
-            </div>
-        </section>
-
+   
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@
     </head>
     <body>
         <main>
-            <button id="logo">
+            <a href="#home" id="logo">
                 <img srcset="resources/logo@2x.png 2x" src="resources/logo.png" alt="Speedometer" />
-            </button>
+            </a>
 
             <section id="home" class="selected">
                 <p>Speedometer is a browser benchmark that measures the responsiveness of Web applications. It uses demo web applications to simulate user actions such as adding to-do items.</p>
@@ -25,7 +25,7 @@
                         <button class="start-tests-button">Start Test</button>
                     </div>
                     <div class="button-row">
-                        <button class="show-about">About Speedometer</button>
+                        <a href="#about" >About Speedometer</button>
                     </div>
                 </div>
             </section>
@@ -52,24 +52,7 @@
                 <div class="buttons">
                     <div class="button-row">
                         <button class="start-tests-button" title="Discard the current results and re-run all tests.">Test Again</button>
-                        <button id="show-details" title="Show detailed results data.">Details</button>
-                    </div>
-                </div>
-            </section>
-
-            <section id="detailed-results">
-                <h1>Detailed Results</h1>
-                <table class="results-table"></table>
-                <table class="results-table"></table>
-                <div class="arithmetic-mean"><label>Arithmetic Mean:</label><span id="results-with-statistics"></span></div>
-                <div class="buttons">
-                    <div class="button-row">
-                        <a class="button" id="download-json" download="speedometer.json" title="Download all result metrics as json string.">Download JSON</a>
-                        <button id="copy-json" title="Copy all result metrics as json string.">Copy JSON</button>
-                    </div>
-                    <div class="button-row">
-                        <button class="start-tests-button" title="Discard the current results and re-run all tests.">Test Again</button>
-                        <button id="show-summary" title="Go back to the simplified summary view.">Summary</button>
+                        <a href="#detailed-results" id="show-details" title="Show detailed results data.">Details</a>
                     </div>
                 </div>
             </section>
@@ -100,7 +83,31 @@
                 <p>Speedometer does not attempt to measure concurrent asynchronous work that does not directly impact the UI thread, which tends not to affect app responsiveness.</p>
 
                 <p class="note"><strong>Note:</strong> Speedometer should not be used as a way to compare the performance of different JavaScript frameworks as work load differs greatly in each framework.</p>
+                <div class="buttons">
+                    <div class="button-row">
+                        <a class="button" href="#home" title="Show main section.">Home</a>
+                    </div>
+                </div>
             </section>
         </main>
+        
+        <!-- Keep Detailed results outside main -->
+        <section id="detailed-results">
+            <h1>Detailed Results</h1>
+            <table class="results-table"></table>
+            <table class="results-table"></table>
+            <div class="arithmetic-mean"><label>Arithmetic Mean:</label><span id="results-with-statistics"></span></div>
+            <div class="buttons">
+                <div class="button-row">
+                    <a class="button" id="download-json" download="speedometer.json" title="Download all result metrics as json string.">Download JSON</a>
+                    <button id="copy-json" title="Copy all result metrics as json string.">Copy JSON</button>
+                </div>
+                <div class="button-row">
+                    <button class="start-tests-button" title="Discard the current results and re-run all tests.">Test Again</button>
+                    <button id="show-summary" title="Go back to the simplified summary view.">Summary</button>
+                </div>
+            </div>
+        </section>
+
     </body>
 </html>

--- a/resources/main.css
+++ b/resources/main.css
@@ -162,7 +162,7 @@ section > p {
     margin: 10px 20px;
 }
 
-section.selected {
+section:target {
     display: block;
 }
 

--- a/resources/main.css
+++ b/resources/main.css
@@ -235,50 +235,50 @@ button.show-about {
     text-align: right;
 }
 
-section#detailed-results > .results-table {
+section#details > .results-table {
     float: left;
     width: 50%;
 }
 
-section#summarized-results > #result-number,
-section#summarized-results > #confidence-number {
+section#summary > #result-number,
+section#summary > #confidence-number {
     font-family: "Futura-CondensedMedium", Futura, "Helvetica Neue", Helvetica, Verdana, sans-serif;
 }
 
-section#summarized-results > #result-number {
+section#summary > #result-number {
     text-align: center;
     font-size: 145px;
     line-height: 145px;
 }
 
-section#summarized-results > #confidence-number {
+section#summary > #confidence-number {
     text-align: center;
     font-size: 36px;
     line-height: 36px;
     color: rgb(128, 128, 128);
 }
 
-section#detailed-results button,
-section#detailed-results .button {
+section#details button,
+section#details .button {
     min-width: 300px;
 }
 
-section#detailed-results > .arithmetic-mean {
+section#details > .arithmetic-mean {
     clear: both;
     padding-top: 32px;
     text-align: center;
 }
 
-section#detailed-results > .arithmetic-mean > label {
+section#details > .arithmetic-mean > label {
     font-weight: bold;
     margin-right: 10px;
 }
 
-section#detailed-results button.show-about {
+section#details button.show-about {
     margin-top: 30px;
 }
 
-section#detailed-results h1 {
+section#details h1 {
     margin-bottom: 10px;
 }
 

--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -21,6 +21,8 @@ class MainBenchmarkClient {
     }
 
     startBenchmark() {
+        if (this._isRunning)
+            return false;
         if (params.suites.length > 0) {
             if (!Suites.enable(params.suites)) {
                 const message = `Suite "${params.suites}" does not exist. No tests to run.`;
@@ -34,8 +36,6 @@ class MainBenchmarkClient {
                 return false;
             }
         }
-        if (this._isRunning)
-            return false;
         this._isRunning = true;
         this.developerMode = params.developerMode;
 

--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -13,9 +13,11 @@ class MainBenchmarkClient {
     _finishedTestCount = 0;
     _progressCompleted = null;
     _isRunning = false;
+    _hasResults = false;
 
     constructor() {
         window.addEventListener("DOMContentLoaded", () => this.prepareUI());
+        this._showSection(window.location.hash);
     }
 
     startBenchmark() {
@@ -32,6 +34,9 @@ class MainBenchmarkClient {
                 return false;
             }
         }
+        if (this._isRunning)
+            return false;
+        this._isRunning = true;
         this.developerMode = params.developerMode;
 
         const enabledSuites = Suites.filter((suite) => !suite.disabled);
@@ -67,7 +72,6 @@ class MainBenchmarkClient {
     }
 
     willStartFirstIteration() {
-        this._isRunning = true;
         this._measuredValuesList = [];
         this._finishedTestCount = 0;
         this._progressCompleted = document.getElementById("progress-completed");
@@ -76,6 +80,7 @@ class MainBenchmarkClient {
     didFinishLastIteration() {
         console.assert(this._isRunning);
         this._isRunning = false;
+        this._hasResults = true;
 
         const scoreResults = this._computeResults(this._measuredValuesList, "score");
         this._updateGaugeNeedle(scoreResults.mean);
@@ -153,7 +158,7 @@ class MainBenchmarkClient {
         const needleAngle = Math.max(0, Math.min(score, 140)) - 70;
         const needleRotationValue = `rotate(${needleAngle}deg)`;
 
-        const gaugeNeedleElement = document.querySelector("#summarized-results > .gauge .needle");
+        const gaugeNeedleElement = document.querySelector("#summary > .gauge .needle");
         gaugeNeedleElement.style.setProperty("-webkit-transform", needleRotationValue);
         gaugeNeedleElement.style.setProperty("-moz-transform", needleRotationValue);
         gaugeNeedleElement.style.setProperty("-ms-transform", needleRotationValue);
@@ -179,17 +184,12 @@ class MainBenchmarkClient {
     }
 
     prepareUI() {
-        window.addEventListener("popstate", this._popStateHandler.bind(this), false);
+        window.addEventListener("hashchange", this._hashChangeHandler.bind(this));
         window.addEventListener("resize", this._resizeScreeHandler.bind(this));
         this._resizeScreeHandler();
 
         document.getElementById("logo").onclick = this._logoClickHandler.bind(this);
-        document.getElementById("show-summary").onclick = this.showResultsSummary.bind(this);
-        document.getElementById("show-details").onclick = this.showResultsDetails.bind(this);
         document.getElementById("copy-json").onclick = this.copyJsonResults.bind(this);
-        document.querySelectorAll(".show-about").forEach((each) => {
-            each.onclick = this.showAbout.bind(this);
-        });
         document.querySelectorAll(".start-tests-button").forEach((button) => {
             button.onclick = this._startBenchmarkHandler.bind(this);
         });
@@ -198,18 +198,8 @@ class MainBenchmarkClient {
             this._startBenchmarkHandler();
     }
 
-    _popStateHandler(event) {
-        // if (event.state) {
-        //     const sectionToShow = event.state.section;
-        //     if (sectionToShow) {
-        //         const sections = document.querySelectorAll("main > section");
-        //         for (let i = 0; i < sections.length; i++) {
-        //             if (sections[i].id === sectionToShow)
-        //                 return this._showSection(sectionToShow, false);
-        //         }
-        //     }
-        // }
-        // return this._showSection("home", false);
+    _hashChangeHandler() {
+        this._showSection(window.location.hash);
     }
 
     _resizeScreeHandler() {
@@ -224,27 +214,23 @@ class MainBenchmarkClient {
 
     _startBenchmarkHandler() {
         if (this.startBenchmark())
-            this._showSection("running");
+            this._showSection("#running");
     }
 
     _logoClickHandler(event) {
         // Prevent any accidental UI changes during benchmark runs.
         if (!this._isRunning)
-            this._showSection("home", true);
+            this._showSection("#home");
         event.preventDefault();
         return false;
     }
 
     showResultsSummary() {
-        this._showSection("summarized-results", true);
+        this._showSection("#summary");
     }
 
     showResultsDetails() {
-        this._showSection("detailed-results", true);
-    }
-
-    showAbout() {
-        this._showSection("about", true);
+        this._showSection("#details");
     }
 
     _getFormattedJSONResult() {
@@ -260,19 +246,22 @@ class MainBenchmarkClient {
         navigator.clipboard.writeText(this._getFormattedJSONResult());
     }
 
-    _showSection(sectionIdentifier, pushState) {
-        window.location.hash = `#${sectionIdentifier}`;
-        // const currentSectionElement = document.querySelector("section.selected");
-        // console.assert(currentSectionElement);
-
-        // const newSectionElement = document.getElementById(sectionIdentifier);
-        // console.assert(newSectionElement);
-
-        // currentSectionElement.classList.remove("selected");
-        // newSectionElement.classList.add("selected");
-
-        // if (pushState)
-        //     history.pushState({ section: sectionIdentifier }, document.title);
+    _showSection(hash) {
+        if (this._isRunning) {
+            window.location.hash = "#running";
+            return;
+        } else if (this._hasResults) {
+            if (hash !== "#summary" && hash !== "#details") {
+                window.location.hash = "#summary";
+                return;
+            }
+        } else {
+            if (hash !== "#home" && hash !== "#about") {
+                window.location.hash = "#home";
+                return;
+            }
+        }
+        window.location.hash = hash || "#home";
     }
 }
 

--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -199,17 +199,17 @@ class MainBenchmarkClient {
     }
 
     _popStateHandler(event) {
-        if (event.state) {
-            const sectionToShow = event.state.section;
-            if (sectionToShow) {
-                const sections = document.querySelectorAll("main > section");
-                for (let i = 0; i < sections.length; i++) {
-                    if (sections[i].id === sectionToShow)
-                        return this._showSection(sectionToShow, false);
-                }
-            }
-        }
-        return this._showSection("home", false);
+        // if (event.state) {
+        //     const sectionToShow = event.state.section;
+        //     if (sectionToShow) {
+        //         const sections = document.querySelectorAll("main > section");
+        //         for (let i = 0; i < sections.length; i++) {
+        //             if (sections[i].id === sectionToShow)
+        //                 return this._showSection(sectionToShow, false);
+        //         }
+        //     }
+        // }
+        // return this._showSection("home", false);
     }
 
     _resizeScreeHandler() {
@@ -261,17 +261,18 @@ class MainBenchmarkClient {
     }
 
     _showSection(sectionIdentifier, pushState) {
-        const currentSectionElement = document.querySelector("section.selected");
-        console.assert(currentSectionElement);
+        window.location.hash = `#${sectionIdentifier}`;
+        // const currentSectionElement = document.querySelector("section.selected");
+        // console.assert(currentSectionElement);
 
-        const newSectionElement = document.getElementById(sectionIdentifier);
-        console.assert(newSectionElement);
+        // const newSectionElement = document.getElementById(sectionIdentifier);
+        // console.assert(newSectionElement);
 
-        currentSectionElement.classList.remove("selected");
-        newSectionElement.classList.add("selected");
+        // currentSectionElement.classList.remove("selected");
+        // newSectionElement.classList.add("selected");
 
-        if (pushState)
-            history.pushState({ section: sectionIdentifier }, document.title);
+        // if (pushState)
+        //     history.pushState({ section: sectionIdentifier }, document.title);
     }
 }
 


### PR DESCRIPTION
- Remove history state 
- Prevent accidentally restarting benchmark in `startBenchmark()`
- Add "home" link to about page
- Add explicit logic in `_showSection(...)` for selecting the allowed views
- Use a-href that point to the shown section
- Use CSS rules to show/hide sections (in preparation for making the details full-width)

Visible change: All urls now have a explicit hash (default is `#home`) 