### PR TITLE
Allow custom section sizes

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,18 +8,19 @@
     </head>
     <body>
         <main>
-            <a href="#home" id="logo">
-                <img srcset="resources/logo@2x.png 2x" src="resources/logo.png" alt="Speedometer" />
-            </a>
-
-            <section id="home" class="selected">
-                <p>Speedometer is a browser benchmark that measures the responsiveness of Web applications. It uses demo web applications to simulate user actions such as adding to-do items.</p>
-                <p id="screen-size-warning">
-                    <strong>
-                        Your browser window is too small. For most accurate results, please make the view port size at least <span id="min-screen-width">850px</span> by <span id="min-screen-height">650px</span>.<br />
-                        It's currently <span id="screen-size"></span>.
-                    </strong>
-                </p>
+            <section id="home">
+                <a href="#home" class="logo">
+                    <img srcset="resources/logo@2x.png 2x" src="resources/logo.png" alt="Speedometer" />
+                </a>
+                <div class="content">
+                    <p>Speedometer is a browser benchmark that measures the responsiveness of Web applications. It uses demo web applications to simulate user actions such as adding to-do items.</p>
+                    <p id="screen-size-warning">
+                        <strong>
+                            Your browser window is too small. For most accurate results, please make the view port size at least <span id="min-screen-width">850px</span> by <span id="min-screen-height">650px</span>.<br />
+                            It's currently <span id="screen-size"></span>.
+                        </strong>
+                    </p>
+                </div>
                 <div class="buttons">
                     <div class="button-row">
                         <button class="start-tests-button">Start Test</button>
@@ -31,6 +32,9 @@
             </section>
 
             <section id="running">
+                <a href="#home" class="logo">
+                    <img srcset="resources/logo@2x.png 2x" src="resources/logo.png" alt="Speedometer" />
+                </a>
                 <div id="testContainer"></div>
                 <div id="progress">
                     <div id="progress-completed"></div>
@@ -42,6 +46,9 @@
             </section>
 
             <section id="summary">
+                <a href="#home" class="logo">
+                    <img srcset="resources/logo@2x.png 2x" src="resources/logo.png" alt="Speedometer" />
+                </a>
                 <h1>Score</h1>
                 <div class="gauge">
                     <div class="window"><div class="needle"></div></div>
@@ -58,51 +65,66 @@
             </section>
 
             <section id="details">
-                <h1>Detailed Results</h1>
-                <table class="results-table"></table>
-                <table class="results-table"></table>
-                <div class="arithmetic-mean"><label>Arithmetic Mean:</label><span id="results-with-statistics"></span></div>
-                <div class="buttons">
-                    <div class="button-row">
-                        <a class="button" id="download-json" download="speedometer.json" title="Download all result metrics as json string.">Download JSON</a>
-                        <button id="copy-json" title="Copy all result metrics as json string.">Copy JSON</button>
+                <a href="#home" class="logo">
+                    <img srcset="resources/logo@2x.png 2x" src="resources/logo.png" alt="Speedometer" />
+                </a>
+                <div class="section-grid">
+                    <h1 class="section-header">Detailed Results</h1>
+                    <div class="section-content">
+                        <table class="results-table"></table>
+                        <table class="results-table"></table>
+                        <div class="arithmetic-mean">
+                            <label>Arithmetic Mean:</label><span id="results-with-statistics"></span>
+                        </div>
                     </div>
-                    <div class="button-row">
-                        <button class="start-tests-button" title="Discard the current results and re-run all tests.">Test Again</button>
-                        <a class="button" href="#summary" title="Go back to the simplified summary view.">Summary</a>
+                    <div class="buttons section-footer">
+                        <div class="button-row">
+                            <a class="button" id="download-json" download="speedometer.json" title="Download all result metrics as json string.">Download JSON</a>
+                            <button id="copy-json" title="Copy all result metrics as json string.">Copy JSON</button>
+                        </div>
+                        <div class="button-row">
+                            <button class="start-tests-button" title="Discard the current results and re-run all tests.">Test Again</button>
+                            <a class="button" href="#summary" title="Go back to the simplified summary view.">Summary</a>
+                        </div>
                     </div>
                 </div>
             </section>
 
             <section id="about">
-                <h1>About Speedometer 2.1</h1>
+                <a href="#home" class="logo">
+                    <img srcset="resources/logo@2x.png 2x" src="resources/logo.png" alt="Speedometer" />
+                </a>
+                <div  class="section-grid">
+                    <h1 class="section-header">About Speedometer 2.1</h1>
+                    <div class="section-content">
+                        <p>Speedometer tests a browser's Web app responsiveness by timing simulated user interactions.</p>
 
-                <p>Speedometer tests a browser's Web app responsiveness by timing simulated user interactions.</p>
+                        <p>
+                            This benchmark simulates user actions for adding, completing, and removing to-do items using multiple examples in TodoMVC. Each example in TodoMVC implements the same todo application using DOM APIs in different ways. Some call
+                            DOM APIs directly from ECMAScript 5 (ES5), ECMASCript 2015 (ES6), ES6 transpiled to ES5, and Elm transpiled to ES5. Others use one of eleven popular JavaScript frameworks: React, React with Redux, Ember.js, Backbone.js, AngularJS,
+                            (new) Angular, Vue.js, jQuery, Preact, Inferno, and Flight. Many of these frameworks are used on the most popular websites in the world, such as Facebook and Twitter. The performance of these types of operations depends on the
+                            speed of the DOM APIs, the JavaScript engine, CSS style resolution, layout, and other technologies.
+                        </p>
 
-                <p>
-                    This benchmark simulates user actions for adding, completing, and removing to-do items using multiple examples in TodoMVC. Each example in TodoMVC implements the same todo application using DOM APIs in different ways. Some call
-                    DOM APIs directly from ECMAScript 5 (ES5), ECMASCript 2015 (ES6), ES6 transpiled to ES5, and Elm transpiled to ES5. Others use one of eleven popular JavaScript frameworks: React, React with Redux, Ember.js, Backbone.js, AngularJS,
-                    (new) Angular, Vue.js, jQuery, Preact, Inferno, and Flight. Many of these frameworks are used on the most popular websites in the world, such as Facebook and Twitter. The performance of these types of operations depends on the
-                    speed of the DOM APIs, the JavaScript engine, CSS style resolution, layout, and other technologies.
-                </p>
+                        <p>
+                            Although user-driven actions like mouse movements and keyboard input cannot be accurately emulated in JavaScript, Speedometer does its best to faithfully replay a typical workload within the demo applications. To make the run time
+                            long enough to measure with the limited precision, we synchronously execute a large number of the operations, such as adding one hundred to-do items.
+                        </p>
 
-                <p>
-                    Although user-driven actions like mouse movements and keyboard input cannot be accurately emulated in JavaScript, Speedometer does its best to faithfully replay a typical workload within the demo applications. To make the run time
-                    long enough to measure with the limited precision, we synchronously execute a large number of the operations, such as adding one hundred to-do items.
-                </p>
+                        <p>
+                            Modern browser engines execute some work asynchronously as an optimization strategy to reduce the run time of synchronous operations. While returning control back to JavaScript execution as soon as possible is worth pursuing, the
+                            run time cost of such an asynchronous work should still be taken into a holistic measurement of web application performance. In addition, some modern JavaScript frameworks such as Vue.js and Preact call into DOM APIs
+                            asynchronously as an optimization technique. Speedometer approximates the run time of this asynchronous work in the UI thread with a zero-second timer that is scheduled immediately after each execution of synchronous operations.
+                        </p>
 
-                <p>
-                    Modern browser engines execute some work asynchronously as an optimization strategy to reduce the run time of synchronous operations. While returning control back to JavaScript execution as soon as possible is worth pursuing, the
-                    run time cost of such an asynchronous work should still be taken into a holistic measurement of web application performance. In addition, some modern JavaScript frameworks such as Vue.js and Preact call into DOM APIs
-                    asynchronously as an optimization technique. Speedometer approximates the run time of this asynchronous work in the UI thread with a zero-second timer that is scheduled immediately after each execution of synchronous operations.
-                </p>
+                        <p>Speedometer does not attempt to measure concurrent asynchronous work that does not directly impact the UI thread, which tends not to affect app responsiveness.</p>
 
-                <p>Speedometer does not attempt to measure concurrent asynchronous work that does not directly impact the UI thread, which tends not to affect app responsiveness.</p>
-
-                <p class="note"><strong>Note:</strong> Speedometer should not be used as a way to compare the performance of different JavaScript frameworks as work load differs greatly in each framework.</p>
-                <div class="buttons">
-                    <div class="button-row">
-                        <a class="button" href="#home" title="Show main section.">Home</a>
+                        <p class="note"><strong>Note:</strong> Speedometer should not be used as a way to compare the performance of different JavaScript frameworks as work load differs greatly in each framework.</p>
+                    </div>
+                    <div class="buttons section-footer">
+                        <div class="button-row">
+                            <a class="button" href="#home" title="Show main section.">Home</a>
+                        </div>
                     </div>
                 </div>
             </section>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
                         <button class="start-tests-button">Start Test</button>
                     </div>
                     <div class="button-row">
-                        <a href="#about" >About Speedometer</a>
+                        <a href="#about">About Speedometer</a>
                     </div>
                 </div>
             </section>
@@ -73,9 +73,7 @@
                     <div class="section-content">
                         <table class="results-table"></table>
                         <table class="results-table"></table>
-                        <div class="arithmetic-mean">
-                            <label>Arithmetic Mean:</label><span id="results-with-statistics"></span>
-                        </div>
+                        <div class="arithmetic-mean"><label>Arithmetic Mean:</label><span id="results-with-statistics"></span></div>
                     </div>
                     <div class="buttons section-footer">
                         <div class="button-row">
@@ -94,27 +92,28 @@
                 <a href="#home" class="logo">
                     <img srcset="resources/logo@2x.png 2x" src="resources/logo.png" alt="Speedometer" />
                 </a>
-                <div  class="section-grid">
+                <div class="section-grid">
                     <h1 class="section-header">About Speedometer 2.1</h1>
                     <div class="section-content">
                         <p>Speedometer tests a browser's Web app responsiveness by timing simulated user interactions.</p>
 
                         <p>
-                            This benchmark simulates user actions for adding, completing, and removing to-do items using multiple examples in TodoMVC. Each example in TodoMVC implements the same todo application using DOM APIs in different ways. Some call
-                            DOM APIs directly from ECMAScript 5 (ES5), ECMASCript 2015 (ES6), ES6 transpiled to ES5, and Elm transpiled to ES5. Others use one of eleven popular JavaScript frameworks: React, React with Redux, Ember.js, Backbone.js, AngularJS,
-                            (new) Angular, Vue.js, jQuery, Preact, Inferno, and Flight. Many of these frameworks are used on the most popular websites in the world, such as Facebook and Twitter. The performance of these types of operations depends on the
-                            speed of the DOM APIs, the JavaScript engine, CSS style resolution, layout, and other technologies.
+                            This benchmark simulates user actions for adding, completing, and removing to-do items using multiple examples in TodoMVC. Each example in TodoMVC implements the same todo application using DOM APIs in different ways. Some
+                            call DOM APIs directly from ECMAScript 5 (ES5), ECMASCript 2015 (ES6), ES6 transpiled to ES5, and Elm transpiled to ES5. Others use one of eleven popular JavaScript frameworks: React, React with Redux, Ember.js,
+                            Backbone.js, AngularJS, (new) Angular, Vue.js, jQuery, Preact, Inferno, and Flight. Many of these frameworks are used on the most popular websites in the world, such as Facebook and Twitter. The performance of these types
+                            of operations depends on the speed of the DOM APIs, the JavaScript engine, CSS style resolution, layout, and other technologies.
                         </p>
 
                         <p>
-                            Although user-driven actions like mouse movements and keyboard input cannot be accurately emulated in JavaScript, Speedometer does its best to faithfully replay a typical workload within the demo applications. To make the run time
-                            long enough to measure with the limited precision, we synchronously execute a large number of the operations, such as adding one hundred to-do items.
+                            Although user-driven actions like mouse movements and keyboard input cannot be accurately emulated in JavaScript, Speedometer does its best to faithfully replay a typical workload within the demo applications. To make the
+                            run time long enough to measure with the limited precision, we synchronously execute a large number of the operations, such as adding one hundred to-do items.
                         </p>
 
                         <p>
-                            Modern browser engines execute some work asynchronously as an optimization strategy to reduce the run time of synchronous operations. While returning control back to JavaScript execution as soon as possible is worth pursuing, the
-                            run time cost of such an asynchronous work should still be taken into a holistic measurement of web application performance. In addition, some modern JavaScript frameworks such as Vue.js and Preact call into DOM APIs
-                            asynchronously as an optimization technique. Speedometer approximates the run time of this asynchronous work in the UI thread with a zero-second timer that is scheduled immediately after each execution of synchronous operations.
+                            Modern browser engines execute some work asynchronously as an optimization strategy to reduce the run time of synchronous operations. While returning control back to JavaScript execution as soon as possible is worth
+                            pursuing, the run time cost of such an asynchronous work should still be taken into a holistic measurement of web application performance. In addition, some modern JavaScript frameworks such as Vue.js and Preact call into
+                            DOM APIs asynchronously as an optimization technique. Speedometer approximates the run time of this asynchronous work in the UI thread with a zero-second timer that is scheduled immediately after each execution of
+                            synchronous operations.
                         </p>
 
                         <p>Speedometer does not attempt to measure concurrent asynchronous work that does not directly impact the UI thread, which tends not to affect app responsiveness.</p>
@@ -129,6 +128,5 @@
                 </div>
             </section>
         </main>
-   
     </body>
 </html>

--- a/resources/main.css
+++ b/resources/main.css
@@ -41,22 +41,10 @@ img {
 }
 
 main {
-    --padding-width: 15px;
-    --border-width: 6px;
-    display: block;
-    position: absolute;
-    width: var(--viewport-width);
-    height: var(--viewport-height);
-    top: 50%;
-    left: 50%;
-    margin-top: calc(var(--viewport-height) / -2 - var(--padding-width) - var(--border-width));
-    margin-left: calc(var(--viewport-width) / -2 - var(--padding-width) - var(--border-width));
-    padding: var(--padding-width);
-    border: var(--border-width) solid var(--foreground);
-    border-radius: 20px;
+
 }
 
-#logo {
+.logo {
     position: absolute;
     left: -70px;
     top: 115px;
@@ -154,16 +142,26 @@ button,
 
 section {
     display: none;
+    --padding-width: 15px;
+    --border-width: 6px;
+    position: absolute;
     width: var(--viewport-width);
     height: var(--viewport-height);
-}
-
-section > p {
-    margin: 10px 20px;
+    top: 50%;
+    left: 50%;
+    margin-top: calc(var(--viewport-height) / -2 - var(--padding-width) - var(--border-width));
+    margin-left: calc(var(--viewport-width) / -2 - var(--padding-width) - var(--border-width));
+    padding: var(--padding-width);
+    border: var(--border-width) solid var(--foreground);
+    border-radius: 20px;
 }
 
 section:target {
     display: block;
+}
+
+section > p {
+    margin: 10px 20px;
 }
 
 #testContainer {
@@ -174,13 +172,13 @@ section:target {
     height: var(--viewport-height);
 }
 
-section#home > p {
+section#home p {
     margin: 0 auto;
     width: 70%;
     text-align: center;
 }
 
-section#home > p:first-child {
+section#home .content {
     margin-top: 160px;
     text-align: center;
 }
@@ -235,11 +233,6 @@ button.show-about {
     text-align: right;
 }
 
-section#details > .results-table {
-    float: left;
-    width: 50%;
-}
-
 section#summary > #result-number,
 section#summary > #confidence-number {
     font-family: "Futura-CondensedMedium", Futura, "Helvetica Neue", Helvetica, Verdana, sans-serif;
@@ -258,18 +251,33 @@ section#summary > #confidence-number {
     color: rgb(128, 128, 128);
 }
 
+section#details {
+/* 
+    FIXME: Enable custom details size
+    --padding: 40px;
+    margin-top: 0px;
+    top: var(--padding);
+    height: calc(100% - 3 * var(--padding));
+*/
+}
+
+section#details .results-table {
+    float: left;
+    width: 50%;
+}
+
 section#details button,
 section#details .button {
     min-width: 300px;
 }
 
-section#details > .arithmetic-mean {
+section#details .arithmetic-mean {
     clear: both;
     padding-top: 32px;
     text-align: center;
 }
 
-section#details > .arithmetic-mean > label {
+section#details .arithmetic-mean > label {
     font-weight: bold;
     margin-right: 10px;
 }
@@ -280,10 +288,6 @@ section#details button.show-about {
 
 section#details h1 {
     margin-bottom: 10px;
-}
-
-section#about {
-    overflow-y: auto;
 }
 
 section#about p {
@@ -299,6 +303,28 @@ section#about h1 {
 
 section#about .note {
     color: rgb(128, 128, 128);
+}
+
+.section-grid {
+    display: grid;
+    width: 100%;
+    height: 100%;
+    grid-template-rows: auto 1fr auto;
+    grid-template-areas:
+        "header"
+        "content"
+        "footer";
+}
+
+.section-header {
+    grid-area: header;
+}
+.section-content {
+    grid-area: content;
+    overflow-y: auto;
+}
+.section-footer {
+    grid-area: footer;
 }
 
 table {

--- a/resources/main.css
+++ b/resources/main.css
@@ -41,7 +41,6 @@ img {
 }
 
 main {
-
 }
 
 .logo {
@@ -252,13 +251,12 @@ section#summary > #confidence-number {
 }
 
 section#details {
-/* 
+    /* 
     FIXME: Enable custom details size
     --padding: 40px;
     margin-top: 0px;
     top: var(--padding);
-    height: calc(100% - 3 * var(--padding));
-*/
+    height: calc(100% - 3 * var(--padding)); */
 }
 
 section#details .results-table {

--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -188,7 +188,7 @@ class MainBenchmarkClient {
         window.addEventListener("resize", this._resizeScreeHandler.bind(this));
         this._resizeScreeHandler();
 
-        document.querySelectorAll("logo").forEach((button) => { 
+        document.querySelectorAll("logo").forEach((button) => {
             button.onclick = this._logoClickHandler.bind(this);
         });
         document.getElementById("copy-json").onclick = this.copyJsonResults.bind(this);

--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -51,7 +51,7 @@ class MainBenchmarkClient {
     }
 
     willAddTestFrame(frame) {
-        const main = document.querySelector("main");
+        const main = document.querySelector("#running");
         const style = getComputedStyle(main);
         frame.style.left = `${main.offsetLeft + parseInt(style.borderLeftWidth) + parseInt(style.paddingLeft)}px`;
         frame.style.top = `${main.offsetTop + parseInt(style.borderTopWidth) + parseInt(style.paddingTop)}px`;
@@ -188,7 +188,9 @@ class MainBenchmarkClient {
         window.addEventListener("resize", this._resizeScreeHandler.bind(this));
         this._resizeScreeHandler();
 
-        document.getElementById("logo").onclick = this._logoClickHandler.bind(this);
+        document.querySelectorAll("logo").forEach((button) => { 
+            button.onclick = this._logoClickHandler.bind(this);
+        });
         document.getElementById("copy-json").onclick = this.copyJsonResults.bind(this);
         document.querySelectorAll(".start-tests-button").forEach((button) => {
             button.onclick = this._startBenchmarkHandler.bind(this);


### PR DESCRIPTION
This PR makes each runner section independent to allow custom sizes.
This is in preparation for PR #42 to allow more space for the details view.

- Move border layout from `main` to each `section`
- Copy logo into every `section`
- Use grid-layout for header/content/footer in about and details view