### PR TITLE
Formatting adjustment

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -48,11 +48,12 @@
     "rules": {
         "array-bracket-spacing": [2, "never"],
         "block-spacing": [2, "always"],
+        "brace-style": 2,
         "comma-dangle": [2, "only-multiline"],
         "comma-spacing": [2, { "before": false, "after": true }],
         "comma-style": [2, "last"],
         "consistent-return": 2,
-        "curly": 0,
+        "curly": ["error", "multi-or-nest", "consistent"],
         "dot-notation": 0,
         "eol-last": 2,
         "eqeqeq": 2,

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
                         <button class="start-tests-button">Start Test</button>
                     </div>
                     <div class="button-row">
-                        <a href="#about" >About Speedometer</a>
+                        <a href="#about">About Speedometer</a>
                     </div>
                 </div>
             </section>
@@ -107,6 +107,5 @@
                 </div>
             </section>
         </main>
-   
     </body>
 </html>

--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -178,9 +178,11 @@ export class BenchmarkRunner {
         await this._appendFrame();
         this._page = new Page(this._frame);
 
-        for (const suite of this._suites)
+        for (const suite of this._suites) {
             if (!suite.disabled)
                 await this._runSuite(suite);
+        }
+
 
         // Remove frame to clear the view for displaying the results.
         this._removeFrame();

--- a/resources/interactive.mjs
+++ b/resources/interactive.mjs
@@ -69,9 +69,8 @@ class InteractiveBenchmarkRunner extends BenchmarkRunner {
             let suiteResults = measuredValues.tests[suiteName];
             for (const testName in suiteResults.tests) {
                 let testResults = suiteResults.tests[testName];
-                for (const subtestName in testResults.tests) {
+                for (const subtestName in testResults.tests)
                     results += `${suiteName} : ${testName} : ${subtestName}: ${testResults.tests[subtestName]} ms\n`;
-                }
             }
             results += `${suiteName} : ${suiteResults.total} ms\n`;
         }
@@ -211,9 +210,8 @@ function startTest() {
     }
 
     const interactiveRunner = new window.BenchmarkRunner(Suites, params.iterationCount);
-    if (!(interactiveRunner instanceof InteractiveBenchmarkRunner)) {
+    if (!(interactiveRunner instanceof InteractiveBenchmarkRunner))
         throw Error("window.BenchmarkRunner must be a subclass of InteractiveBenchmarkRunner");
-    }
 
     // Don't call step while step is already executing.
     document.body.appendChild(createUIForSuites(Suites, interactiveRunner.runStep.bind(interactiveRunner), interactiveRunner.runSuites.bind(interactiveRunner)));

--- a/tests/server.mjs
+++ b/tests/server.mjs
@@ -19,9 +19,9 @@ const STATIC_PATH = path.join(process.cwd(), "./");
 const toBool = [() => true, () => false];
 
 export default function serve(port) {
-    if (!port) {
+    if (!port)
         throw new Error("Port is required");
-    }
+
     const prepareFile = async (url) => {
         const paths = [STATIC_PATH, url];
         if (url.endsWith("/"))


### PR DESCRIPTION
A small adjustment to our eslint rules, to hopefully address the issue of: 
"No curly braces around single line statements."

note: the format command always runs prettier before eslint, since eslint needs to correct some prettier formatting rules that we can't control. 

Hope this gets us closer to the desired style guide.