### PR TITLE
emit start-suite and end-suite performance marks outside of the timed region

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -191,8 +191,10 @@ export class BenchmarkRunner {
 
     async _runSuite(suite) {
         await this._prepareSuite(suite);
+        performance.mark(`start-suite-${suite.name}`);
         for (const test of suite.tests)
             await this._runTestAndRecordResults(suite, test);
+        performance.mark(`end-suite-${suite.name}`);
     }
 
     async _prepareSuite(suite) {

--- a/tests/benchmark-runner-tests.mjs
+++ b/tests/benchmark-runner-tests.mjs
@@ -148,7 +148,7 @@ describe("BenchmarkRunner", () => {
         });
 
         describe("_runSuite", () => {
-            let _prepareSuiteStub, _runTestAndRecordResultsStub;
+            let _prepareSuiteStub, _runTestAndRecordResultsStub, peformanceMarkSpy;
 
             const suite = SUITES_FIXTURE[0];
 
@@ -157,6 +157,7 @@ describe("BenchmarkRunner", () => {
 
                 _runTestAndRecordResultsStub = stub(runner, "_runTestAndRecordResults").callsFake(() => null);
 
+                peformanceMarkSpy = spy(window.performance, "mark");
                 runner._runSuite(suite);
             });
 
@@ -166,6 +167,9 @@ describe("BenchmarkRunner", () => {
 
             it("should run and record results for every test in suite", async () => {
                 assert.calledThrice(_runTestAndRecordResultsStub);
+                assert.calledWith(peformanceMarkSpy, "start-suite-Suite 1");
+                assert.calledWith(peformanceMarkSpy, "end-suite-Suite 1");
+                expect(peformanceMarkSpy.callCount).to.equal(2);
             });
         });
     });


### PR DESCRIPTION
Fixes #105 