### PR TITLE
Add RAF and setTimout based testRun initiation

### DIFF
--- a/resources/params.mjs
+++ b/resources/params.mjs
@@ -65,7 +65,7 @@ class Params {
             }
             throw new Error(`Invalid ${name} param: ${testInitiatorParam}, choices are ${choices} `);
         }
-        if (!initiatorChoices.includes(defaultValue)) 
+        if (!initiatorChoices.includes(defaultValue))
             throw Error(`Invalid default value: ${defaultValue}`);
         return defaultValue;
     }

--- a/resources/params.mjs
+++ b/resources/params.mjs
@@ -8,6 +8,7 @@ class Params {
     iterationCount = 10;
     suites = [];
     testInitiator = "timeout"; // or "raf"
+    asyncInitiator = "timeout"; // or "raf"
 
     constructor(searchParams = undefined) {
         if (searchParams)
@@ -46,16 +47,27 @@ class Params {
         }
         this.developerMode = searchParams.has("developerMode");
         searchParams.delete("developerMode");
+        this.testInitiator = this._parseInitiator(searchParams, "testInitiator");
+        this.asyncInitiator = this._parseInitiator(searchParams, "asyncInitiator");
         const unused = Array.from(searchParams.keys());
         if (unused.length > 0)
             console.error("Got unused search params", unused);
-        if (searchParams.has("testInitiator")) {
-            const testInitiatorParam = searchParams.get("testInitiator");
-            const choices = ["timeout", "raf"];
-            if (!choices.includes(testInitiatorParam))
-                throw new Error(`Invalid testInitiator param: ${testInitiatorParam}, choices are ${choices} `);
-            this.testInitiator = testInitiatorParam;
+    }
+
+    _parseInitiator(searchParams, name, defaultValue = "timeout") {
+        const initiatorChoices = ["timeout", "raf"];
+        if (searchParams.has(name)) {
+            const testInitiatorParam = searchParams.get(name);
+            console.log(testInitiatorParam);
+            if (initiatorChoices.includes(testInitiatorParam)) {
+                searchParams.delete(name);
+                return testInitiatorParam;
+            }
+            throw new Error(`Invalid ${name} param: ${testInitiatorParam}, choices are ${choices} `);
         }
+        if (!initiatorChoices.includes(defaultValue)) 
+            throw Error(`Invalid default value: ${defaultValue}`);
+        return defaultValue;
     }
 
     toSearchParams() {

--- a/resources/params.mjs
+++ b/resources/params.mjs
@@ -7,6 +7,7 @@ class Params {
     startAutomatically = false;
     iterationCount = 10;
     suites = [];
+    testInitiator = "timeout"; // or "raf"
 
     constructor(searchParams = undefined) {
         if (searchParams)
@@ -48,6 +49,13 @@ class Params {
         const unused = Array.from(searchParams.keys());
         if (unused.length > 0)
             console.error("Got unused search params", unused);
+        if (searchParams.has("testInitiator")) {
+            const testInitiatorParam = searchParams.get("testInitiator");
+            const choices = ["timeout", "raf"];
+            if (!choices.includes(testInitiatorParam))
+                throw new Error(`Invalid testInitiator param: ${testInitiatorParam}, choices are ${choices} `);
+            this.testInitiator = testInitiatorParam;
+        }
     }
 
     toSearchParams() {


### PR DESCRIPTION
Seems like a lot of the perf different isn't coming actually from the  change in the async measurements but rather in using RAF to start the test.
This PR adds `params.testInitiator` to change the mode for local investigation.

RAF-based test initiation seems to decrease the score by 15% on Chrome, by 25% on Safari and 4% on Firefox, which is rather unexpected.