### PR TITLE
Add warmup test suite

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -127,7 +127,7 @@ const WarmupSuite = {
     },
     tests: [
         // Make sure to run ever page.method once at least
-        new BenchmarkTestStep(`WarmingUpPageMethods`, (page) => {
+        new BenchmarkTestStep("WarmingUpPageMethods", (page) => {
             let results = [];
             results.push(page.querySelector(".testItem"));
             results.push(page.querySelectorAll(".item"));
@@ -163,7 +163,7 @@ const WarmupSuite = {
             item.dispatchEvent("wheel", wheelEventOptions, WheelEvent);
         }),
     ],
-}
+};
 
 export class BenchmarkRunner {
     constructor(suites, client) {
@@ -212,7 +212,6 @@ export class BenchmarkRunner {
     }
 
     async runMultipleIterations(iterationCount) {
-
         if (this._client?.willStartFirstIteration)
             await this._client.willStartFirstIteration(iterationCount);
         for (let i = 0; i < iterationCount; i++)
@@ -232,6 +231,7 @@ export class BenchmarkRunner {
             if (!suite.disabled)
                 await this._runSuite(suite);
         }
+
 
         // Remove frame to clear the view for displaying the results.
         this._removeFrame();

--- a/resources/warmup/index.html
+++ b/resources/warmup/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Warmup Page</title>
+  </head>
+  <body style="background-color:white">
+    <h1>WARMUP</h1>
+    <div >
+        <div class="item">item 1</div>
+        <div class="item">item 2</div>
+        <div class="item">item 3</div>
+        <div class="item">item 4</div>
+        <div class="item">item 5</div>
+        <div class="item" id="testItem">item 6</div>
+    </div>
+  </body>
+</html>

--- a/resources/warmup/index.html
+++ b/resources/warmup/index.html
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <title>Warmup Page</title>
-  </head>
-  <body style="background-color:white">
-    <h1>WARMUP</h1>
-    <div >
-        <div class="item">item 1</div>
-        <div class="item">item 2</div>
-        <div class="item">item 3</div>
-        <div class="item">item 4</div>
-        <div class="item">item 5</div>
-        <div class="item" id="testItem">item 6</div>
-    </div>
-  </body>
+    <head>
+        <meta charset="utf-8" />
+        <title>Warmup Page</title>
+    </head>
+    <body style="background-color: white">
+        <h1>WARMUP</h1>
+        <div>
+            <div class="item">item 1</div>
+            <div class="item">item 2</div>
+            <div class="item">item 3</div>
+            <div class="item">item 4</div>
+            <div class="item">item 5</div>
+            <div class="item" id="testItem">item 6</div>
+        </div>
+    </body>
 </html>


### PR DESCRIPTION
We've noticed that we get lazy compilation events for test-runner methods.
By doing running a warmup suite first, we can avoid this addition noise during measurements.