### PR TITLE
Todomvc scripts cleanup

### DIFF
--- a/resources/todomvc/architecture-examples/backbone/package.json
+++ b/resources/todomvc/architecture-examples/backbone/package.json
@@ -8,8 +8,8 @@
     },
     "private": true,
     "scripts": {
-        "dev": "http-server ./ -p 7001 -c-1 --cors",
         "build": "node scripts/build.js",
+        "dev": "http-server ./ -p 7001 -c-1 --cors",
         "serve": "http-server ./dist -p 7002 -c-1 --cors"
     },
     "dependencies": {

--- a/resources/todomvc/architecture-examples/emberjs/package.json
+++ b/resources/todomvc/architecture-examples/emberjs/package.json
@@ -12,9 +12,10 @@
     },
     "scripts": {
         "build": "NODE_OPTIONS=--openssl-legacy-provider ember build --environment=production",
+        "dev": "NODE_OPTIONS=--openssl-legacy-provider ember serve",
+        "serve": "NODE_OPTIONS=--openssl-legacy-provider ember serve",
         "lint:hbs": "ember-template-lint .",
         "lint:hbs:fix": "ember-template-lint . --fix",
-        "start": "NODE_OPTIONS=--openssl-legacy-provider ember serve",
         "test": "npm-run-all lint test:*",
         "test:ember": "ember test"
     },

--- a/resources/todomvc/architecture-examples/preact/package.json
+++ b/resources/todomvc/architecture-examples/preact/package.json
@@ -9,9 +9,9 @@
     },
     "scripts": {
         "build": "rollup -c --bundleConfigAsCjs",
-        "watch": "ROLLUP_WATCH=true rollup -c -w --bundleConfigAsCjs",
+        "dev": "npm-run-all --parallel serve watch",
         "serve": "http-server ./dist -p 7002 -c-1 --cors -o",
-        "start": "npm-run-all --parallel serve watch"
+        "watch": "ROLLUP_WATCH=true rollup -c -w --bundleConfigAsCjs"
     },
     "devDependencies": {
         "@babel/plugin-transform-react-jsx": "^7.21.0",

--- a/resources/todomvc/architecture-examples/react-redux/package.json
+++ b/resources/todomvc/architecture-examples/react-redux/package.json
@@ -8,8 +8,8 @@
         "npm": ">=8.19.3"
     },
     "scripts": {
-        "start": "webpack serve --open --config webpack.dev.js",
         "build": "webpack --config webpack.prod.js",
+        "dev": "webpack serve --open --config webpack.dev.js",
         "serve": "http-server ./dist -p 7002 -c-1 --cors",
         "test": "jest"
     },

--- a/resources/todomvc/architecture-examples/react/package.json
+++ b/resources/todomvc/architecture-examples/react/package.json
@@ -8,8 +8,8 @@
         "npm": ">=8.19.3"
     },
     "scripts": {
-        "start": "webpack serve --open --config webpack.dev.js",
         "build": "webpack --config webpack.prod.js",
+        "dev": "webpack serve --open --config webpack.dev.js",
         "serve": "http-server ./dist -p 7002 -c-1 --cors",
         "test": "jest"
     },


### PR DESCRIPTION
It got confusing with "dev" and "start" scripts to spin up the local dev environment. 
This cleanup uses a consistent script name ("dev") for all updated workloads. 

@kara 