### PR TITLE
Add a method to the Page object so that we can force a reflow in a frame

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -57,6 +57,10 @@ class Page {
         return null;
     }
 
+    forceReflowAndGetHeight() {
+        return this._frame.contentDocument.body.getBoundingClientRect().height;
+    }
+
     _wrapElement(element) {
         return new PageElement(element);
     }
@@ -240,10 +244,9 @@ export class BenchmarkRunner {
         setTimeout(() => {
             // Some browsers don't immediately update the layout for paint.
             // Force the layout here to ensure we're measuring the layout time.
-            const height = this._frame.contentDocument.body.getBoundingClientRect().height;
+            const height = page.forceReflowAndGetHeight();
             const asyncEndTime = performance.now();
             const asyncTime = asyncEndTime - asyncStartTime;
-            this._frame.contentWindow._unusedHeightValue = height; // Prevent dead code elimination.
             performance.mark(asyncEndLabel);
             performance.measure(`${suite.name}.${test.name}-sync`, startLabel, syncEndLabel);
             performance.measure(`${suite.name}.${test.name}-async`, asyncStartLabel, asyncEndLabel);


### PR DESCRIPTION
Some tests may need to force a reflow between steps, so I added this capability to the "page" tool and used it in the runner.

I tested in Firefox and Chrome, but I don't have Mac or Windows so I can't test Safari and Edge. It would be good if somebody could test it as well.

What do you think?

[results.txt](https://github.com/WebKit/Speedometer/files/11180313/results.txt)
