### PR TITLE
Don't specify the base URL as an absolute path.

### DIFF
--- a/resources/todomvc/architecture-examples/angular/dist/index.html
+++ b/resources/todomvc/architecture-examples/angular/dist/index.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>Angular</title>
-  <base href="/resources/todomvc/architecture-examples/angular/dist/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 <link rel="stylesheet" href="styles.5fd101737c0aaaef.css"></head>

--- a/resources/todomvc/architecture-examples/angular/src/index.html
+++ b/resources/todomvc/architecture-examples/angular/src/index.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>Angular</title>
-  <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>


### PR DESCRIPTION
This allows the benchmark to be ran inside another directory in a local HTTP server.