### PR TITLE
reduce flashing by setting a light background to better match the content of the tests

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -143,6 +143,7 @@ export class BenchmarkRunner {
         style.border = "0px none";
         style.position = "absolute";
         frame.setAttribute("scrolling", "no");
+        frame.className = "test-runner";
         const computedStyle = getComputedStyle(document.body);
         const marginLeft = parseInt(computedStyle.marginLeft);
         const marginTop = parseInt(computedStyle.marginTop);

--- a/resources/main.css
+++ b/resources/main.css
@@ -5,6 +5,7 @@
     --foreground-alpha: rgba(235, 235, 235, 0.2);
     --inactive-color: rgb(128, 128, 128);
     --background: rgb(46, 51, 55);
+    --running-background: #f5f5f5;
     --highlight: rgb(232, 79, 79);
     --text-width: 650px;
     --metrics-line-height: 25px;
@@ -263,6 +264,10 @@ button.show-about {
     position: absolute;
     right: 6px;
     text-align: right;
+}
+
+iframe.test-runner {
+    background: var(--running-background);
 }
 
 section#summary > #result-number,


### PR DESCRIPTION
This should improve the state of #37.

Before:
![before-PR](https://github.com/WebKit/Speedometer/assets/95570/1cc3af20-55e6-43c1-8480-9a1fa35abe02)


After:
![after-PR](https://github.com/WebKit/Speedometer/assets/95570/afbbe6a2-a2c5-4c9f-8dd5-6e2a7014a514)


