### PR TITLE
Use more performance.mark for suites

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -202,7 +202,7 @@ export class BenchmarkRunner {
             await this._runTestAndRecordResults(suite, test);
         performance.mark(suiteEndLabel);
 
-        performance.measure(`suite-${suite.name}`, suitePrepareLabel, suiteEndLabel);
+        performance.measure(`suite-${suite.name}`, suiteStartLabel, suiteEndLabel);
     }
 
     async _prepareSuite(suite) {

--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -190,11 +190,19 @@ export class BenchmarkRunner {
     }
 
     async _runSuite(suite) {
+        const suitePrepareLabel = `suite-${suite.name}-prepare`;
+        const suiteStartLabel = `suite-${suite.name}-start`;
+        const suiteEndLabel = `suite-${suite.name}-end`;
+
+        performance.mark(suitePrepareLabel);
         await this._prepareSuite(suite);
-        performance.mark(`start-suite-${suite.name}`);
+        
+        performance.mark(suiteStartLabel);
         for (const test of suite.tests)
             await this._runTestAndRecordResults(suite, test);
-        performance.mark(`end-suite-${suite.name}`);
+        performance.mark(suiteEndLabel);
+
+        performance.measure(`suite-${suite.name}`, suitePrepareLabel, suiteEndLabel);
     }
 
     async _prepareSuite(suite) {

--- a/tests/benchmark-runner-tests.mjs
+++ b/tests/benchmark-runner-tests.mjs
@@ -167,9 +167,10 @@ describe("BenchmarkRunner", () => {
 
             it("should run and record results for every test in suite", async () => {
                 assert.calledThrice(_runTestAndRecordResultsStub);
-                assert.calledWith(peformanceMarkSpy, "start-suite-Suite 1");
-                assert.calledWith(peformanceMarkSpy, "end-suite-Suite 1");
-                expect(peformanceMarkSpy.callCount).to.equal(2);
+                assert.calledWith(peformanceMarkSpy, "suite-Suite 1-prepare");
+                assert.calledWith(peformanceMarkSpy, "suite-Suite 1-start");
+                assert.calledWith(peformanceMarkSpy, "suite-Suite 1-end");
+                expect(peformanceMarkSpy.callCount).to.equal(3);
             });
         });
     });


### PR DESCRIPTION
- Use more `performance.mark` for suites.
- Pre-build the mark strings upfront

![Screenshot 2023-05-15 at 14 16 58](https://github.com/WebKit/Speedometer/assets/129550/4fb01628-8376-43d1-8497-d2199c852f04)
