### PR TITLE
Make the number of airports per group configurable and use it in tests

### DIFF
--- a/resources/tentative/charts/dist/observable-plot.html
+++ b/resources/tentative/charts/dist/observable-plot.html
@@ -4,7 +4,18 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Observable Plot</title>
-      <script type="module" crossorigin src="./assets/plot-e9515604.js"></script>
+<style>
+label {
+  display: inline-flex;
+  align-content: center;
+  gap: 3px;
+  margin: 0 3px;
+}
+#airport-group-size {
+  min-width: 30px;
+}
+</style>
+      <script type="module" crossorigin src="./assets/plot-1a97ddda.js"></script>
     </head>
     <body>
         <div id="app">
@@ -13,6 +24,11 @@
             <button id="add-stacked-chart-button" type="button">Add a stacked chart</button>
             <button id="add-dotted-chart-button" type="button">Add a dotted chart</button>
             <button id="reset" type="button">Reset</button>
+            <label>
+              Number of airports to keep in each group:
+              <span id="airport-group-size"></span>
+              <input type="range" id="airport-group-size-input" min="0" max="20" value="6">
+            </label>
         </div>
         <div id="chart"></div>
         

--- a/resources/tentative/charts/observable-plot.html
+++ b/resources/tentative/charts/observable-plot.html
@@ -4,6 +4,17 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Observable Plot</title>
+<style>
+label {
+  display: inline-flex;
+  align-content: center;
+  gap: 3px;
+  margin: 0 3px;
+}
+#airport-group-size {
+  min-width: 30px;
+}
+</style>
     </head>
     <body>
         <div id="app">
@@ -12,6 +23,11 @@
             <button id="add-stacked-chart-button" type="button">Add a stacked chart</button>
             <button id="add-dotted-chart-button" type="button">Add a dotted chart</button>
             <button id="reset" type="button">Reset</button>
+            <label>
+              Number of airports to keep in each group:
+              <span id="airport-group-size"></span>
+              <input type="range" id="airport-group-size-input" min="0" max="20" value="6">
+            </label>
         </div>
         <div id="chart"></div>
         <script type="module" src="/observable-plot.js"></script>

--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -377,10 +377,21 @@ Suites.push({
     url: "tentative/charts/dist/observable-plot.html",
     async prepare(page) {},
     tests: [
-        new BenchmarkTestStep("Prepare", (page) => {
+        new BenchmarkTestStep("Prepare 6", (page) => {
             page.querySelector("#prepare").click();
         }),
-        new BenchmarkTestStep("Stacked", (page) => {
+        new BenchmarkTestStep("Stacked by 6", (page) => {
+            page.querySelector("#reset").click();
+            page.querySelector("#add-stacked-chart-button").click();
+        }),
+        new BenchmarkTestStep("Prepare 20", (page) => {
+            const sizeSlider = page.querySelector("#airport-group-size-input");
+            sizeSlider.setValue(20);
+            sizeSlider.dispatchEvent("input");
+            sizeSlider.dispatchEvent("change");
+            page.querySelector("#prepare").click();
+        }),
+        new BenchmarkTestStep("Stacked by 20", (page) => {
             page.querySelector("#reset").click();
             page.querySelector("#add-stacked-chart-button").click();
         }),


### PR DESCRIPTION
This is a follow-up to #144.

In Firefox I see more work related to styling in the async marker when configured to "20".
What do you think @rniwa?