### PR TITLE
Replace innerHTML by DOMParser in a workload

### DIFF
--- a/resources/todomvc/vanilla-examples/javascript-es5/dist/view.js
+++ b/resources/todomvc/vanilla-examples/javascript-es5/dist/view.js
@@ -36,7 +36,7 @@
     };
 
     View.prototype._clearCompletedButton = function (completedCount, visible) {
-        this.$clearCompleted.innerHTML = this.template.clearCompletedButton(completedCount);
+        this.$clearCompleted.textContent = this.template.clearCompletedButton(completedCount);
         this.$clearCompleted.style.display = visible ? "block" : "none";
     };
 
@@ -89,17 +89,22 @@
         });
     };
 
+    View.prototype._replaceContentWithHtml = function (element, html) {
+        const parsedDocument = new DOMParser().parseFromString(html, "text/html");
+        element.replaceChildren(...parsedDocument.body.childNodes);
+    };
+
     View.prototype.render = function (viewCmd, parameter) {
         var self = this;
         var viewCommands = {
             showEntries: function () {
-                self.$todoList.innerHTML = self.template.show(parameter);
+                self._replaceContentWithHtml(self.$todoList, self.template.show(parameter));
             },
             removeItem: function () {
                 self._removeItem(parameter);
             },
             updateElementCount: function () {
-                self.$todoItemCounter.innerHTML = self.template.itemCounter(parameter);
+                self._replaceContentWithHtml(self.$todoItemCounter, self.template.itemCounter(parameter));
             },
             clearCompletedButton: function () {
                 self._clearCompletedButton(parameter.completed, parameter.visible);

--- a/resources/todomvc/vanilla-examples/javascript-es5/src/view.js
+++ b/resources/todomvc/vanilla-examples/javascript-es5/src/view.js
@@ -36,7 +36,7 @@
     };
 
     View.prototype._clearCompletedButton = function (completedCount, visible) {
-        this.$clearCompleted.innerHTML = this.template.clearCompletedButton(completedCount);
+        this.$clearCompleted.textContent = this.template.clearCompletedButton(completedCount);
         this.$clearCompleted.style.display = visible ? "block" : "none";
     };
 
@@ -89,17 +89,22 @@
         });
     };
 
+    View.prototype._replaceContentWithHtml = function (element, html) {
+        const parsedDocument = new DOMParser().parseFromString(html, "text/html");
+        element.replaceChildren(...parsedDocument.body.childNodes);
+    };
+
     View.prototype.render = function (viewCmd, parameter) {
         var self = this;
         var viewCommands = {
             showEntries: function () {
-                self.$todoList.innerHTML = self.template.show(parameter);
+                self._replaceContentWithHtml(self.$todoList, self.template.show(parameter));
             },
             removeItem: function () {
                 self._removeItem(parameter);
             },
             updateElementCount: function () {
-                self.$todoItemCounter.innerHTML = self.template.itemCounter(parameter);
+                self._replaceContentWithHtml(self.$todoItemCounter, self.template.itemCounter(parameter));
             },
             clearCompletedButton: function () {
                 self._clearCompletedButton(parameter.completed, parameter.visible);


### PR DESCRIPTION
In this PR I replaced the use of innerHTML by 2 alternatives as found in some newer libraries: `DOMParser` and `range.createContextualFragment`, each in a different benchmark implementation.
__Update__: In the current version of the patch, only `DOMParser` is used.

This follows the quick research I made in https://docs.google.com/document/d/1sHjNPpu1HgnmLmrN3ae9m_ATkI5FEuAIJZahLvrE7-A/edit?usp=sharing.

You can use this URL to run these changes on your computer:
https://replace-innerhtml--speedometer-preview.netlify.app/?suite=TodoMVC-JavaScript-ES5,TodoMVC-JavaScript-ES6,TodoMVC-JavaScript-ES6-Webpack

ES6-Webpack hasn't changed but I included it in the above link as a comparison.

~~Based on research we could also add a template + innerHTML test as in `lit-html`, but because we also plan to have a dedicated `lit-html` benchmark I decided to use `createContextualFragment` instead, despite that it doesn't look like to be as used as the other options.~~

For Firefox, we run about 48% slower overall.

Firefox:
Before:
![image](https://github.com/WebKit/Speedometer/assets/454175/8dc5ba67-5233-4860-aa25-457bdc2c3232)

After:
![image](https://github.com/WebKit/Speedometer/assets/454175/2fda2ad8-39c8-48c3-80d0-6a9e3bc3cc6e)

Chrome:
Before:
![image](https://github.com/WebKit/Speedometer/assets/454175/16322a94-8c46-4f5f-a5e1-53c9c27f5bac)

After:
![image](https://github.com/WebKit/Speedometer/assets/454175/952d02c0-2923-45e2-8f8f-9db9421fd4d6)

