### PR TITLE
Add raf based measurement

### DIFF
--- a/resources/params.mjs
+++ b/resources/params.mjs
@@ -8,6 +8,7 @@ class Params {
     iterationCount = 10;
     suites = [];
     useWarmupSuite = false;
+    measurementMethod = 'timer';
 
     constructor(searchParams = undefined) {
         if (searchParams)
@@ -46,14 +47,22 @@ class Params {
         }
         this.developerMode = searchParams.has("developerMode");
         searchParams.delete("developerMode");
-        const unused = Array.from(searchParams.keys());
-        if (unused.length > 0)
-            console.error("Got unused search params", unused);
 
         if (searchParams.has("useWarmupSuite")) {
             this.useWarmupSuite = true;
             searchParams.delete("useWarmupSuite");
         }
+
+        if (searchParams.has("measurementMethod")) {
+            this.measurementMethod = searchParams.get("measurementMethod");
+            if (this.measurementMethod != 'timer' && this.measurementMethod != 'raf')
+                throw new Error(`Invalid measurement method: ${this.measurementMethod}`);
+            searchParams.delete("measurementMethod");
+        }
+
+        const unused = Array.from(searchParams.keys());
+        if (unused.length > 0)
+            console.error("Got unused search params", unused);
     }
 
     toSearchParams() {

--- a/tests/benchmark-runner-tests.mjs
+++ b/tests/benchmark-runner-tests.mjs
@@ -177,40 +177,19 @@ describe("BenchmarkRunner", () => {
 
     describe("Test", () => {
         describe("_runTestAndRecordResults", () => {
-            let _runTestSpy;
+            let peformanceMarkSpy;
 
             const suite = SUITES_FIXTURE[0];
 
             before(async () => {
                 await runner._appendFrame();
-
-                _runTestSpy = spy(runner, "_runTest");
-
+                peformanceMarkSpy = spy(window.performance, "mark");
                 await runner._runTestAndRecordResults(suite, suite.tests[0]);
-            });
-
-            it("should run the test with the correct arguments", () => {
-                assert.calledWith(_runTestSpy, suite, suite.tests[0], runner._page);
             });
 
             it("should run client pre and post hooks if present", () => {
                 assert.calledWith(runner._client.willRunTest, suite, suite.tests[0]);
                 assert.calledWith(runner._client.didRunTest, suite, suite.tests[0]);
-            });
-        });
-
-        describe("_runTest", () => {
-            let peformanceMarkSpy, _testFnSpy, page;
-            const callback = stub();
-            const suite = SUITES_FIXTURE[0];
-
-            before(async () => {
-                page = { _frame: await runner._appendFrame() };
-                peformanceMarkSpy = spy(window.performance, "mark");
-                _testFnSpy = suite.tests[0].run.callsFake(() => null);
-
-                stubPerformanceNowCalls(8000, 10000, 12000, 13000);
-                runner._runTest(suite, suite.tests[0], page, callback);
             });
 
             it("should write performance marks at the start and end of the test with the correct test name", () => {
@@ -219,15 +198,6 @@ describe("BenchmarkRunner", () => {
                 assert.calledWith(peformanceMarkSpy, "Suite 1.Test 1-async-start");
                 assert.calledWith(peformanceMarkSpy, "Suite 1.Test 1-async-end");
                 expect(peformanceMarkSpy.callCount).to.equal(4);
-            });
-
-            it("should run the test", () => {
-                assert.calledWith(_testFnSpy, page);
-            });
-
-            it("should fire the callback with correct arguments for sync time, async time, and frame height", async () => {
-                await new Promise((resolve) => requestAnimationFrame(resolve));
-                assert.calledOnce(callback);
             });
         });
 


### PR DESCRIPTION
This PR adds a new query string parameter requestAnimationFrame, which takes the value of either "timer" or "raf". "timer" is the existing and default measurement method. When it's "raf", we use two consecutive requestAnimationFrame first of which runs the sync step and second of which schedules a 0s timer to signify the end of async step.
