### PR TITLE
News-site: adjust test steps

### DIFF
--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -338,76 +338,64 @@ Suites.push({
         new BenchmarkTestStep("NavigateToUS", (page) => {
             page.querySelector("#close-toast-link").click();
             page.layout();
-            for (let i = 0; i < 5; i++) {
+            for (let i = 0; i < 25; i++) {
                 page.querySelector("#navbar-dropdown-toggle").click();
                 page.layout();
                 page.querySelector("#navbar-dropdown-toggle").click();
-                page.layout();
-                page.querySelector("#navbar-navlist-us-link").click();
-                page.layout();
-                page.querySelector("#home-link").click();
                 page.layout();
             }
+            page.querySelector("#navbar-navlist-us-link").click();
+            page.layout();
         }),
         new BenchmarkTestStep("NavigateToWorld", (page) => {
-            for (let i = 0; i < 5; i++) {
+            for (let i = 0; i < 25; i++) {
                 page.querySelector("#navbar-dropdown-toggle").click();
                 page.layout();
                 page.querySelector("#navbar-dropdown-toggle").click();
-                page.layout();
-                page.querySelector("#navbar-navlist-world-link").click();
-                page.layout();
-                page.querySelector("#home-link").click();
                 page.layout();
             }
+            page.querySelector("#navbar-navlist-world-link").click();
+            page.layout();
         }),
         new BenchmarkTestStep("NavigateToPolitics", (page) => {
-            for (let i = 0; i < 5; i++) {
+            for (let i = 0; i < 25; i++) {
                 page.querySelector("#navbar-dropdown-toggle").click();
                 page.layout();
                 page.querySelector("#navbar-dropdown-toggle").click();
-                page.layout();
-                page.querySelector("#navbar-navlist-politics-link").click();
-                page.layout();
-                page.querySelector("#home-link").click();
                 page.layout();
             }
+            page.querySelector("#navbar-navlist-politics-link").click();
+            page.layout();
         }),
         new BenchmarkTestStep("NavigateToBusiness", (page) => {
-            for (let i = 0; i < 5; i++) {
+            for (let i = 0; i < 25; i++) {
                 page.querySelector("#navbar-dropdown-toggle").click();
                 page.layout();
                 page.querySelector("#navbar-dropdown-toggle").click();
-                page.layout();
-                page.querySelector("#navbar-navlist-business-link").click();
-                page.layout();
-                page.querySelector("#home-link").click();
                 page.layout();
             }
+            page.querySelector("#navbar-navlist-business-link").click();
+            page.layout();
         }),
         new BenchmarkTestStep("NavigateToOpinion", (page) => {
-            for (let i = 0; i < 5; i++) {
+            for (let i = 0; i < 25; i++) {
                 page.querySelector("#navbar-dropdown-toggle").click();
                 page.layout();
                 page.querySelector("#navbar-dropdown-toggle").click();
-                page.layout();
-                page.querySelector("#navbar-navlist-opinion-link").click();
-                page.layout();
-                page.querySelector("#home-link").click();
                 page.layout();
             }
+            page.querySelector("#navbar-navlist-opinion-link").click();
+            page.layout();
         }),
         new BenchmarkTestStep("NavigateToHealth", (page) => {
-            for (let i = 0; i < 5; i++) {
+            for (let i = 0; i < 25; i++) {
                 page.querySelector("#navbar-dropdown-toggle").click();
                 page.layout();
                 page.querySelector("#navbar-dropdown-toggle").click();
-                page.layout();
-                page.querySelector("#navbar-navlist-health-link").click();
-                page.layout();
-                page.querySelector("#home-link").click();
                 page.layout();
             }
+            page.querySelector("#navbar-navlist-health-link").click();
+            page.layout();
         }),
     ],
 });


### PR DESCRIPTION
To avoid to run into the safari limitation, I adjusted the test: 
`SecurityError: Attempt to use history.replaceState() more than 100 times per 30 seconds.`

Details:
<img width="597" alt="Screenshot 2023-05-23 at 4 18 54 PM" src="https://github.com/WebKit/Speedometer/assets/372973/0b4d7149-36cf-40f8-a884-58d33c5e1e95">

With this change we limit the amount of history api calls.

Snapshot from chrome:

before change:
<img width="1185" alt="Screenshot 2023-05-23 at 4 07 46 PM" src="https://github.com/WebKit/Speedometer/assets/372973/b2692c42-3c80-4aaf-bd91-c37fa37a507f">

after change:
<img width="1216" alt="Screenshot 2023-05-23 at 4 14 40 PM" src="https://github.com/WebKit/Speedometer/assets/372973/b90cdbe8-37e6-4055-ae2f-0caad8519eb1">

