### PR TITLE
Add a meta viewport tag so that the viewport ias always the same size…

### DIFF
--- a/InteractiveRunner.html
+++ b/InteractiveRunner.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta name="viewport" content="width=850" />
         <title>Speedometer 3.0 Interactive Runner</title>
         <script src="resources/interactive.mjs" type="module"></script>
         <link rel="icon" href="resources/favicon.png" />

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta name="viewport" content="width=850" />
         <title>Speedometer 3.0</title>
         <link rel="stylesheet" href="resources/main.css" />
         <link rel="icon" href="resources/favicon.png" />


### PR DESCRIPTION
… on all mobile browsers

Fixes #130

The Editor tests still don't show the same thing on Firefox vs Chrome on Android, but this is already a first step.

[deploy preview](https://meta-viewport--speedometer-preview.netlify.app/)
[deploy preview for editor tests](https://meta-viewport--speedometer-preview.netlify.app/?suite=Editor-Codemirror,Editor-Tiptap)
[current branch](https://speedometer-preview.netlify.app/)
[current branch for editor tests](https://speedometer-preview.netlify.app/?suite=Editor-Codemirror,Editor-Tiptap)
