### PR TITLE
Add more markers

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -239,7 +239,7 @@ export class BenchmarkRunner {
         const iterationEndLabel = "iteration-end";
         for (let i = 0; i < iterationCount; i++) {
             performance.mark(iterationStartLabel);
-            await this._runAllSuites(i);
+            await this._runAllSuites();
             performance.mark(iterationEndLabel);
             performance.measure(`iteration-${i}`, iterationStartLabel, iterationEndLabel);
         }
@@ -276,7 +276,7 @@ export class BenchmarkRunner {
         return frame;
     }
 
-    async _runAllSuites(iteration) {
+    async _runAllSuites() {
         this._measuredValues = { tests: {}, total: 0, mean: NaN, geomean: NaN, score: NaN };
 
         const prepareStartLabel = "runner-prepare-start";

--- a/tests/benchmark-runner-tests.mjs
+++ b/tests/benchmark-runner-tests.mjs
@@ -150,10 +150,11 @@ describe("BenchmarkRunner", () => {
 
             it("should run and record results for every test in suite", async () => {
                 assert.calledThrice(_runTestAndRecordResultsStub);
-                assert.calledWith(performanceMarkSpy, "suite-Suite 1-prepare");
+                assert.calledWith(performanceMarkSpy, "suite-Suite 1-prepare-start");
+                assert.calledWith(performanceMarkSpy, "suite-Suite 1-prepare-end");
                 assert.calledWith(performanceMarkSpy, "suite-Suite 1-start");
                 assert.calledWith(performanceMarkSpy, "suite-Suite 1-end");
-                expect(performanceMarkSpy.callCount).to.equal(3);
+                expect(performanceMarkSpy.callCount).to.equal(4);
             });
         });
     });


### PR DESCRIPTION
Adding more markers to simplify checking if work is measured
- Add iteration-X for each runner iteration
- Add runner-prepare and runner-finalize to annotate time it takes for adding/removing the iframe
- Use suite-X-prepare