### PR TITLE
Better copy-support for detailed results table

### DIFF
--- a/resources/main.css
+++ b/resources/main.css
@@ -73,6 +73,10 @@ img {
     -webkit-user-drag: none;
 }
 
+.no-select {
+    user-select: none;
+}
+
 main {
 }
 
@@ -446,6 +450,8 @@ table .number {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    direction: rtl;
+    text-align: left;
 }
 
 section#details h1 {

--- a/resources/metric-ui.mjs
+++ b/resources/metric-ui.mjs
@@ -26,7 +26,7 @@ export function renderMetricView(viewParams) {
         .map(
             (metric, i) => `
                 <tr >
-                    <td class="${colors[i % colors.length]}" >●</td>
+                    <td class="${colors[i % colors.length]} no-select" >●</td>
                     <td class="label">${metric.shortName}</td>
                     <td class="number">${metric.mean.toFixed(2)}</td>
                     <td>±</td>
@@ -39,12 +39,14 @@ export function renderMetricView(viewParams) {
         <dl class="metric">
             <dt><h3>${title}<h3></dt>
             <dd>
-                <div class="metric-chart" onclick="document.body.classList.toggle('relative-charts')">
-                    <div class="metric-chart-absolute">
-                        ${absoluteScatterPlot}
-                    </div>
-                    <div class="metric-chart-relative">
-                        ${normalizedScatterPlot}
+                <div class="metric-chart"">
+                    <div onclick="document.body.classList.toggle('relative-charts')">
+                        <div class="metric-chart-absolute">
+                            ${absoluteScatterPlot}
+                        </div>
+                        <div class="metric-chart-relative">
+                            ${normalizedScatterPlot}
+                        </div>
                     </div>
                     <table class="chart chart-legend">${legend}</table>
                 </div>
@@ -259,7 +261,7 @@ function renderScatterPlot({ values, width = 500, height, trackHeight, xAxisPosi
         <svg class="scatter-plot chart"
             width="${width}" height="${height}"
             viewBox="${`0 0 ${width} ${height}`}">
-            <g class="horizontal-axis">
+            <g class="horizontal-axis no-select">
                 <line
                     x1="${0}" x2="${width}"
                     y1="${axisY - axisMarginY}" y2="${axisY - axisMarginY}"


### PR DESCRIPTION
Make sure we can easily copy the whole detailed results page as formatted text.

- Only toggle charts when clicking on charts
- Don't copy chart legend bullet
- Don't copy chart axis labels

Drive-by-fix:
- Put abbreviation ellipsis for chart legends at the beginning so we don't hide the more important metric suffix