### PR TITLE
Add warmupBeforeSync parameter, which triggers 100ms of infinite loop before each sync step.

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -327,6 +327,10 @@ export class BenchmarkRunner {
         let asyncStartTime;
         let asyncTime;
         const runSync = () => {
+            if (params.warmupBeforeSync) {
+                const startTime = performance.now();
+                while (performance.now() - startTime < params.warmupBeforeSync); // Infinite loop for the specified ms.
+            }
             performance.mark(startLabel);
             const syncStartTime = performance.now();
             test.run(this._page);

--- a/resources/params.mjs
+++ b/resources/params.mjs
@@ -51,6 +51,13 @@ class Params {
             searchParams.delete("useWarmupSuite");
         }
 
+        if (searchParams.has("warmupBeforeSync")) {
+            this.warmupBeforeSync = parseInt(searchParams.get("warmupBeforeSync"));
+            if (this.warmupBeforeSync < 1)
+                throw new Error(`Invalid warmupBeforeSync param: ${this.warmupBeforeSync}`);
+            searchParams.delete("warmupBeforeSync");
+        }
+
         if (searchParams.has("measurementMethod")) {
             this.measurementMethod = searchParams.get("measurementMethod");
             if (this.measurementMethod !== "timer" && this.measurementMethod !== "raf")


### PR DESCRIPTION
This will allow us to evaluate the impact of using rAF vs. timer with regards to CPU throttling.