### PR TITLE
Reduce the react stockcharts steps

### DIFF
--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -503,11 +503,11 @@ Suites.push({
             let x = 150;
             let y = 200;
             const coords = (i) => ({ clientX: x + i * 10, clientY: y + i * 2, bubbles: true, cancelable: true });
-            for (let i = 0; i < 100; ) {
-                cursor.dispatchEvent("mousedown", coords(i), MouseEvent);
-                for (let j = 10; j--; )
-                    cursor.dispatchEvent("mousemove", coords(++i), MouseEvent);
-                cursor.dispatchEvent("mouseup", coords(i), MouseEvent);
+            for (let i = 0; i < 5; i++) {
+                cursor.dispatchEvent("mousedown", coords(0), MouseEvent);
+                for (let j = 0; j < 10; j++)
+                    cursor.dispatchEvent("mousemove", coords(j), MouseEvent);
+                cursor.dispatchEvent("mouseup", coords(10), MouseEvent);
             }
         }),
         new BenchmarkTestStep("ZoomTheChart", (page) => {
@@ -521,31 +521,7 @@ Suites.push({
                 bubbles: true,
                 cancelable: true,
             };
-            for (let i = 0; i < 30; i++)
-                cursor.dispatchEvent("wheel", event, WheelEvent);
-
-            event = {
-                clientX: 650,
-                clientY: 200,
-                deltaMode: 0,
-                delta: 10,
-                deltaY: 10,
-                bubbles: true,
-                cancelable: true,
-            };
-            for (let i = 0; i < 10; i++)
-                cursor.dispatchEvent("wheel", event, WheelEvent);
-
-            event = {
-                clientX: 200,
-                clientY: 200,
-                deltaMode: 0,
-                delta: -10,
-                deltaY: -10,
-                bubbles: true,
-                cancelable: true,
-            };
-            for (let i = 0; i < 10; i++)
+            for (let i = 0; i < 15; i++)
                 cursor.dispatchEvent("wheel", event, WheelEvent);
         }),
     ],


### PR DESCRIPTION
#97 

There are several goals for this patch:
* make the workload more realistic
* make this test faster.

I decided to reduce the amount of events sent for the "pan the chart" step, and cut down the work in the "zoom the chart" step.

Now, for the "pan the chart" step, instead of moving the mouse 1000 times, it's now 50 times.
For the "zoom in" step, instead of 50 times, it's now 15 times.

[base branch from #176](https://stabilize-react-stockcharts--speedometer-preview.netlify.app/?suite=React-Stockcharts-SVG)
[deploy preview](https://split-react-stockcharts--speedometer-preview.netlify.app/?suite=React-Stockcharts-SVG)

Firefox before/after
![image](https://github.com/WebKit/Speedometer/assets/454175/1083f72e-d3b2-48b6-84e9-007154feab84)
![image](https://github.com/WebKit/Speedometer/assets/454175/11652753-0cce-45ca-8043-54fc45c23fcb)

Chrome before/after
![image](https://github.com/WebKit/Speedometer/assets/454175/0b13bc3e-2f03-47ea-890b-33e82d4a8625)
![image](https://github.com/WebKit/Speedometer/assets/454175/2febbf59-ffc4-4c20-8f68-25dfa89dc3b4)

Chrome seems to benefit more than Firefox from this change, but we think it's a more realistic workload.
In more details: Chrome benefits a lot from the changes to the "pan the chart" step, but Firefox doesn't. However both benefits similarly for the reduction of the "zoom the chart" step (about 50%). It would be great to know the result for Safari @rniwa.

What do you all think?