### PR TITLE
[codemirror] Mock requestAnimationFrame to setTimeout so that we don'…

### DIFF
--- a/resources/tentative/editors/codemirror.html
+++ b/resources/tentative/editors/codemirror.html
@@ -126,6 +126,12 @@
             </div>
             <div id="editor"></div>
         </div>
+        <script>
+            // This hack allows to capture the work normally happening in a rAF. We
+            // may be able to remove it if the runner improves.
+            window.requestAnimationFrame = (cb) => window.setTimeout(cb, 0);
+            window.cancelAnimationFrame = window.clearTimeout;
+        </script>
         <script type="module">
             import { code as shorttext } from "./shorttext.js";
             import { code as longtext } from "./longtext.js";

--- a/resources/tentative/editors/dist/assets/codemirror-77870192.js
+++ b/resources/tentative/editors/dist/assets/codemirror-77870192.js
@@ -21841,11 +21841,10 @@ async function editor(element, value) {
       changes: { from: 0, to: view.state.doc.length, insert: value2 }
     }),
     format(on) {
-      if (on && extensions.length == 2) {
+      if (on && extensions.length === 2)
         extensions.push(lang);
-      } else if (!on && extensions.length == 3) {
+      else if (!on && extensions.length === 3)
         extensions.pop();
-      }
       view.dispatch({
         effects: StateEffect.reconfigure.of(extensions)
       });

--- a/resources/tentative/editors/dist/assets/tiptap-39715a58.js
+++ b/resources/tentative/editors/dist/assets/tiptap-39715a58.js
@@ -16294,11 +16294,10 @@ async function editor(element, value) {
       element.scrollTop = 0;
     },
     format(on) {
-      if (on) {
+      if (on)
         editor2.chain().focus().selectAll().setBold().setTextSelection(0).run();
-      } else {
+      else
         editor2.chain().focus().selectAll().unsetBold().setTextSelection(0).run();
-      }
     }
   };
 }

--- a/resources/tentative/editors/dist/codemirror.html
+++ b/resources/tentative/editors/dist/codemirror.html
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         
         <title>CodeMirror Test</title>
-      <script type="module" crossorigin src="./assets/codemirror-302399bc.js"></script>
+      <script type="module" crossorigin src="./assets/codemirror-77870192.js"></script>
       <link rel="modulepreload" crossorigin href="./assets/index.es-02a92ebc.js">
       <link rel="stylesheet" href="./assets/index-2feebe42.css">
     </head>
@@ -129,6 +129,12 @@
             </div>
             <div id="editor"></div>
         </div>
+        <script>
+            // This hack allows to capture the work normally happening in a rAF. We
+            // may be able to remove it if the runner improves.
+            window.requestAnimationFrame = (cb) => window.setTimeout(cb, 0);
+            window.cancelAnimationFrame = window.clearTimeout;
+        </script>
         
     </body>
 </html>

--- a/resources/tentative/editors/dist/tiptap.html
+++ b/resources/tentative/editors/dist/tiptap.html
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         
         <title>TipTap Test</title>
-      <script type="module" crossorigin src="./assets/tiptap-d12427c8.js"></script>
+      <script type="module" crossorigin src="./assets/tiptap-39715a58.js"></script>
       <link rel="modulepreload" crossorigin href="./assets/index.es-02a92ebc.js">
       <link rel="stylesheet" href="./assets/index-2feebe42.css">
     </head>


### PR DESCRIPTION
…t lose any work in the async time

I noticed that we were sometimes missing work in the async part of the "long" step for codemirror, both in Chrome and Firefox (both with and without the raf-based runner).
With this hack that also used elsewhere, this doesn't seem to happen anymore.

/cc @flashdesignory 