### PR TITLE
Add Suite tags for complex filtering

### DIFF
--- a/resources/developer-mode.mjs
+++ b/resources/developer-mode.mjs
@@ -160,9 +160,13 @@ function updateURL() {
     }
 
     if (!selectedSuites.length || selectedSuites.length === Suites.length) {
+        url.searchParams.delete("tag");
+        url.searchParams.delete("tags");
         url.searchParams.delete("suites");
         url.searchParams.delete("suite");
     } else {
+        url.searchParams.delete("tag");
+        url.searchParams.delete("tags");
         url.searchParams.delete("suite");
         url.searchParams.set("suites", selectedSuites.join(","));
     }

--- a/resources/interactive.mjs
+++ b/resources/interactive.mjs
@@ -196,9 +196,14 @@ function createUIForSuites(suites, onStep, onRunSuites) {
 }
 
 function startTest() {
+    let message;
     if (params.suites.length > 0) {
-        if (!Suites.enable(params.suites)) {
-            const message = `Suite "${params.suites}" does not exist. No tests to run.`;
+        if (!Suites.enable(params.suites))
+            message = `Suite "${params.suites}" does not exist. No tests to run.`;
+    } else if (params.tags.length > 0) {
+
+    }
+    if (message) {
             alert(message);
             console.error(
                 message,
@@ -206,7 +211,6 @@ function startTest() {
                 "\nValid values:",
                 Suites.map((each) => each.name)
             );
-        }
     }
 
     const interactiveRunner = new window.BenchmarkRunner(Suites, params.iterationCount);

--- a/resources/interactive.mjs
+++ b/resources/interactive.mjs
@@ -196,22 +196,8 @@ function createUIForSuites(suites, onStep, onRunSuites) {
 }
 
 function startTest() {
-    let message;
-    if (params.suites.length > 0) {
-        if (!Suites.enable(params.suites))
-            message = `Suite "${params.suites}" does not exist. No tests to run.`;
-    } else if (params.tags.length > 0) {
-
-    }
-    if (message) {
-            alert(message);
-            console.error(
-                message,
-                params.suites,
-                "\nValid values:",
-                Suites.map((each) => each.name)
-            );
-    }
+    if (params.suites.length > 0 || params.tags.length > 0)
+        Suites.enable(params.suites, params.tags);
 
     const interactiveRunner = new window.BenchmarkRunner(Suites, params.iterationCount);
     if (!(interactiveRunner instanceof InteractiveBenchmarkRunner))

--- a/resources/main.css
+++ b/resources/main.css
@@ -99,7 +99,6 @@ main {
     top: -110px;
 }
 
-
 h1 {
     margin-top: 30px;
     font-size: 40px;

--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -232,8 +232,8 @@ class MainBenchmarkClient {
             button.onclick = this._startBenchmarkHandler.bind(this);
         });
 
-        if (params.suites.length > 0)
-            Suites.enable(params.suites);
+        if (params.suites.length > 0 || params.tags.length > 0)
+            Suites.enable(params.suites, params.tags);
 
         if (params.developerMode) {
             this._developerModeContainer = createDeveloperModeContainer(Suites);

--- a/resources/params.mjs
+++ b/resources/params.mjs
@@ -8,6 +8,8 @@ class Params {
     startAutomatically = false;
     iterationCount = 10;
     suites = [];
+    // A list of tags to filter suites
+    tags = [];
     // Toggle running a dummy suite once before the normal test suites.
     useWarmupSuite = false;
     // Change how a test measurement is triggered and async time is measured:
@@ -63,6 +65,18 @@ class Params {
             searchParams.delete("suite");
             searchParams.delete("suites");
         }
+
+        if (searchParams.has("tag") || searchParams.has("tags")) {
+            if (searchParams.has("tag") && searchParams.has("tags"))
+                throw new Error("Params 'tag' and 'tags' can not be used together.");
+            if (this.suites.length)
+                throw new Error("'suites' and 'tags' cannot be used together.");
+            const value = searchParams.get("tag") || searchParams.get("tags");
+            this.tags = value.split(",");
+            searchParams.delete("tag");
+            searchParams.delete("tags");
+        }
+
         this.developerMode = searchParams.has("developerMode");
         searchParams.delete("developerMode");
 

--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -16,6 +16,7 @@ Suites.enable = function (names) {
 Suites.push({
     name: "TodoMVC-JavaScript-ES5",
     url: "todomvc/vanilla-examples/javascript-es5/dist/index.html",
+    tags: ["todomvc"],
     async prepare(page) {
         (await page.waitForElement(".new-todo")).focus();
     },
@@ -44,6 +45,7 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-JavaScript-ES6",
     url: "todomvc/vanilla-examples/javascript-es6/dist/index.html",
+    tags: ["todomvc"],
     async prepare(page) {
         const element = await page.waitForElement(".new-todo");
         element.focus();
@@ -73,6 +75,7 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-JavaScript-ES6-Webpack",
     url: "todomvc/vanilla-examples/javascript-es6-webpack/dist/index.html",
+    tags: ["todomvc"],
     async prepare(page) {
         const element = await page.waitForElement(".new-todo");
         element.focus();
@@ -102,6 +105,7 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-React",
     url: "todomvc/architecture-examples/react/dist/index.html#/home",
+    tags: ["todomvc"],
     async prepare(page) {
         const element = await page.waitForElement(".new-todo");
         element.focus();
@@ -131,6 +135,7 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-React-Complex-DOM",
     url: "tentative/complex-static-html/dist/index.html#/home",
+    tags: ["todomvc"],
     async prepare(page) {
         const element = await page.waitForElement(".new-todo");
         element.focus();
@@ -160,6 +165,7 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-React-Redux",
     url: "todomvc/architecture-examples/react-redux/dist/index.html",
+    tags: ["todomvc"],
     async prepare(page) {
         const element = await page.waitForElement(".new-todo");
         element.focus();
@@ -188,6 +194,7 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-Backbone",
     url: "todomvc/architecture-examples/backbone/dist/index.html",
+    tags: ["todomvc"],
     async prepare(page) {
         await page.waitForElement("#appIsReady");
         const newTodo = page.querySelector(".new-todo");
@@ -218,6 +225,7 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-Angular",
     url: "todomvc/architecture-examples/angular/dist/index.html",
+    tags: ["todomvc"],
     async prepare(page) {
         const element = await page.waitForElement(".new-todo");
         element.focus();
@@ -247,6 +255,7 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-Vue",
     url: "todomvc/architecture-examples/vue/dist/index.html",
+    tags: ["todomvc"],
     async prepare(page) {
         const element = await page.waitForElement(".new-todo");
         element.focus();
@@ -276,6 +285,7 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-jQuery",
     url: "todomvc/architecture-examples/jquery/dist/index.html",
+    tags: ["todomvc"],
     async prepare(page) {
         await page.waitForElement("#appIsReady");
         const newTodo = page.getElementById("new-todo");
@@ -304,6 +314,7 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-Preact",
     url: "todomvc/architecture-examples/preact/dist/index.html#/home",
+    tags: ["todomvc"],
     async prepare(page) {
         const element = await page.waitForElement(".new-todo");
         element.focus();
@@ -332,6 +343,7 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-Svelte",
     url: "todomvc/architecture-examples/svelte/dist/index.html",
+    tags: ["todomvc"],
     async prepare(page) {
         const element = await page.waitForElement(".new-todo");
         element.focus();
@@ -360,6 +372,7 @@ Suites.push({
 Suites.push({
     name: "NewsSite-Next",
     url: "tentative/newssite/news-next/dist/index.html#/home",
+    tags: ["tentative"],
     async prepare(page) {
         await page.waitForElement("#navbar-dropdown-toggle");
     },
@@ -400,6 +413,7 @@ Suites.push({
 Suites.push({
     name: "Editor-CodeMirror",
     url: "tentative/editors/dist/codemirror.html",
+    tags: ["tentative"],
     async prepare(page) {},
     tests: [
         new BenchmarkTestStep("Create", (page) => {
@@ -420,6 +434,7 @@ Suites.push({
 Suites.push({
     name: "Editor-TipTap",
     url: "tentative/editors/dist/tiptap.html",
+    tags: ["tentative"],
     async prepare(page) {},
     tests: [
         new BenchmarkTestStep("Create", (page) => {
@@ -440,6 +455,7 @@ Suites.push({
 Suites.push({
     name: "Charts-observable-plot",
     url: "tentative/charts/dist/observable-plot.html",
+    tags: ["tentative", "chart"],
     async prepare(page) {},
     tests: [
         new BenchmarkTestStep("Prepare 6", (page) => {
@@ -470,6 +486,7 @@ Suites.push({
 Suites.push({
     name: "Charts-chartjs",
     url: "tentative/charts/dist/chartjs.html",
+    tags: ["tentative", "chart"],
     async prepare(page) {},
     tests: [
         new BenchmarkTestStep("Prepare", (page) => {
@@ -491,6 +508,7 @@ Suites.push({
 Suites.push({
     name: "React-Stockcharts-SVG",
     url: "tentative/react-stockcharts/build/index.html?type=svg",
+    tags: ["tentative", "chart", "svg"],
     async prepare(page) {
         await page.waitForElement("#render");
     },
@@ -527,5 +545,10 @@ Suites.push({
     ],
 });
 
+const Tags = new Set(Suites.flatMap(suite => suite.tags));
+
 Object.freeze(Suites);
+Object.freeze(Tags);
+
 globalThis.Suites = Suites;
+globalThis.Tags = Tags;


### PR DESCRIPTION
- Each suite has a set of tags
  - "all" applies to all suites
  - "default" applies to suites that are enabled by default (and not tentative)
  - "tentative" applies to suites that are in the tentative directory
- `&tags=` can be used for filtering Suites by tag