### PR TITLE
[Editors] Group the Create step into the next step

### DIFF
--- a/resources/editors/codemirror.html
+++ b/resources/editors/codemirror.html
@@ -143,7 +143,6 @@
 
             let editorContainer = document.querySelector("#editor");
             let editorInstance = null;
-            let editorPromise = null;
 
             let buttons = {
                 create: document.querySelector("#create"),
@@ -162,14 +161,11 @@
             buttons.layout.addEventListener("click", layout);
 
             buttons.create.addEventListener("click", (e) => {
-                if (!editorPromise) {
-                    editorPromise = editor(editorContainer);
-                    editorPromise.then((instance) => {
-                        editorInstance = instance;
-                        editorInstance.ready.then(() => {
-                            buttons.unhighlight.classList.add("active", "true");
-                            buttons.create.setAttribute("disabled", "true");
-                        });
+                if (!editorInstance) {
+                    editorInstance = editor(editorContainer);
+                    editorInstance.ready.then(() => {
+                        buttons.unhighlight.classList.add("active", "true");
+                        buttons.create.setAttribute("disabled", "true");
                     });
                 }
             });

--- a/resources/editors/codemirror.js
+++ b/resources/editors/codemirror.js
@@ -6,7 +6,7 @@ import { javascript } from "@codemirror/lang-javascript";
 let lang = javascript();
 let extensions = [basicSetup, EditorView.lineWrapping];
 
-export default async function (element, value) {
+export default function (element, value) {
     let view = new EditorView({
         extensions,
         parent: element,

--- a/resources/editors/dist/assets/codemirror-521de7ab.js
+++ b/resources/editors/dist/assets/codemirror-521de7ab.js
@@ -21817,7 +21817,7 @@ const autoCloseTags = /* @__PURE__ */ EditorView.inputHandler.of((view, from, to
 });
 let lang = javascript();
 let extensions = [basicSetup, EditorView.lineWrapping];
-async function editor(element, value) {
+function editor(element, value) {
   let view = new EditorView({
     extensions,
     parent: element,
@@ -21853,7 +21853,6 @@ async function editor(element, value) {
 }
 let editorContainer = document.querySelector("#editor");
 let editorInstance = null;
-let editorPromise = null;
 let buttons = {
   create: document.querySelector("#create"),
   highlight: document.querySelector("#highlight"),
@@ -21870,14 +21869,11 @@ buttons.long.addEventListener("click", long);
 buttons.short.addEventListener("click", short);
 buttons.layout.addEventListener("click", layout);
 buttons.create.addEventListener("click", (e) => {
-  if (!editorPromise) {
-    editorPromise = editor(editorContainer);
-    editorPromise.then((instance) => {
-      editorInstance = instance;
-      editorInstance.ready.then(() => {
-        buttons.unhighlight.classList.add("active", "true");
-        buttons.create.setAttribute("disabled", "true");
-      });
+  if (!editorInstance) {
+    editorInstance = editor(editorContainer);
+    editorInstance.ready.then(() => {
+      buttons.unhighlight.classList.add("active", "true");
+      buttons.create.setAttribute("disabled", "true");
     });
   }
 });

--- a/resources/editors/dist/assets/tiptap-95a40ba8.js
+++ b/resources/editors/dist/assets/tiptap-95a40ba8.js
@@ -16265,7 +16265,7 @@ const StarterKit = Extension.create({
     return extensions2;
   }
 });
-async function editor(element, value) {
+function editor(element, value) {
   let editor2 = new Editor({
     element,
     extensions: [StarterKit],
@@ -16303,7 +16303,6 @@ async function editor(element, value) {
 }
 let editorContainer = document.querySelector("#editor");
 let editorInstance = null;
-let editorPromise = null;
 let buttons = {
   create: document.querySelector("#create"),
   highlight: document.querySelector("#highlight"),
@@ -16320,14 +16319,11 @@ buttons.long.addEventListener("click", long);
 buttons.short.addEventListener("click", short);
 buttons.layout.addEventListener("click", layout);
 buttons.create.addEventListener("click", (e) => {
-  if (!editorPromise) {
-    editorPromise = editor(editorContainer);
-    editorPromise.then((instance) => {
-      editorInstance = instance;
-      editorInstance.ready.then(() => {
-        buttons.unhighlight.classList.add("active", "true");
-        buttons.create.setAttribute("disabled", "true");
-      });
+  if (!editorInstance) {
+    editorInstance = editor(editorContainer);
+    editorInstance.ready.then(() => {
+      buttons.unhighlight.classList.add("active", "true");
+      buttons.create.setAttribute("disabled", "true");
     });
   }
 });

--- a/resources/editors/dist/codemirror.html
+++ b/resources/editors/dist/codemirror.html
@@ -10,7 +10,7 @@
             window.requestIdleCallback = undefined;
             window.cancelIdleCallback = undefined;
         </script>
-      <script type="module" crossorigin src="./assets/codemirror-77870192.js"></script>
+      <script type="module" crossorigin src="./assets/codemirror-521de7ab.js"></script>
       <link rel="modulepreload" crossorigin href="./assets/index.es-02a92ebc.js">
       <link rel="stylesheet" href="./assets/index-2feebe42.css">
     </head>

--- a/resources/editors/dist/tiptap.html
+++ b/resources/editors/dist/tiptap.html
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         
         <title>TipTap Test</title>
-      <script type="module" crossorigin src="./assets/tiptap-85e2a257.js"></script>
+      <script type="module" crossorigin src="./assets/tiptap-95a40ba8.js"></script>
       <link rel="modulepreload" crossorigin href="./assets/index.es-02a92ebc.js">
       <link rel="stylesheet" href="./assets/index-2feebe42.css">
     </head>

--- a/resources/editors/tiptap.html
+++ b/resources/editors/tiptap.html
@@ -133,7 +133,6 @@
 
             let editorContainer = document.querySelector("#editor");
             let editorInstance = null;
-            let editorPromise = null;
 
             let buttons = {
                 create: document.querySelector("#create"),
@@ -152,14 +151,11 @@
             buttons.layout.addEventListener("click", layout);
 
             buttons.create.addEventListener("click", (e) => {
-                if (!editorPromise) {
-                    editorPromise = editor(editorContainer);
-                    editorPromise.then((instance) => {
-                        editorInstance = instance;
-                        editorInstance.ready.then(() => {
-                            buttons.unhighlight.classList.add("active", "true");
-                            buttons.create.setAttribute("disabled", "true");
-                        });
+                if (!editorInstance) {
+                    editorInstance = editor(editorContainer);
+                    editorInstance.ready.then(() => {
+                        buttons.unhighlight.classList.add("active", "true");
+                        buttons.create.setAttribute("disabled", "true");
                     });
                 }
             });

--- a/resources/editors/tiptap.js
+++ b/resources/editors/tiptap.js
@@ -2,7 +2,7 @@
 import { Editor } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 
-export default async function (element, value) {
+export default function (element, value) {
     let editor = new Editor({
         element,
         extensions: [StarterKit],

--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -492,11 +492,9 @@ Suites.push({
     tags: ["editor"],
     async prepare(page) {},
     tests: [
-        new BenchmarkTestStep("Create", (page) => {
+        new BenchmarkTestStep("Long", (page) => {
             page.querySelector("#create").click();
             page.querySelector("#layout").click();
-        }),
-        new BenchmarkTestStep("Long", (page) => {
             page.querySelector("#long").click();
             page.querySelector("#layout").click();
         }),
@@ -513,11 +511,9 @@ Suites.push({
     tags: ["editor"],
     async prepare(page) {},
     tests: [
-        new BenchmarkTestStep("Create", (page) => {
+        new BenchmarkTestStep("Long", (page) => {
             page.querySelector("#create").click();
             page.querySelector("#layout").click();
-        }),
-        new BenchmarkTestStep("Long", (page) => {
             page.querySelector("#long").click();
             page.querySelector("#layout").click();
         }),


### PR DESCRIPTION
This is a tentative to reduce the variance in Chrome. There's still a variance for the first run especially, but the create step doesn't contribute to it anymore. It was a quite short step so I believe it makes sense. 
I moved the create step in the "long" step. I had to refactor a few things in the workloads because of this.

[main branch](https://speedometer-preview.netlify.app/?suite=Editor-Codemirror,Editor-Tiptap)
[main branch with raf](https://speedometer-preview.netlify.app/?suite=Editor-Codemirror,Editor-Tiptap&measurementMethod=raf)
[this patch's preview](https://group-more-editor-steps--speedometer-preview.netlify.app/?suite=Editor-Codemirror,Editor-Tiptap)
[this patch's preview with raf](https://group-more-editor-steps--speedometer-preview.netlify.app/?suite=Editor-Codemirror,Editor-Tiptap&measurementMethod=raf)

Tell me what you all think!