### PR TITLE
Reduce version number letter spacing

### DIFF
--- a/resources/main.css
+++ b/resources/main.css
@@ -92,7 +92,7 @@ main {
 .version {
     transform: rotate(-90deg);
     font-size: 65px;
-    font-family: Futura-Medium, Futura, "Helvetica Neue", Helvetica, Verdana, sans-serif;
+    font-family: Futura-Medium, Futura, Roboto, "Helvetica Neue", Helvetica, Verdana, sans-serif;
     font-style: italic;
     letter-spacing: -0.05em;
     position: absolute;

--- a/resources/main.css
+++ b/resources/main.css
@@ -89,6 +89,7 @@ main {
     cursor: pointer;
     text-decoration: none;
 }
+
 .version {
     transform: rotate(-90deg);
     font-size: 65px;
@@ -96,7 +97,7 @@ main {
     font-style: italic;
     letter-spacing: -0.05em;
     position: absolute;
-    right: -0px;
+    right: 0;
     top: -105px;
 }
 

--- a/resources/main.css
+++ b/resources/main.css
@@ -94,9 +94,10 @@ main {
     font-size: 65px;
     font-family: Futura-Medium, Futura, "Helvetica Neue", Helvetica, Verdana, sans-serif;
     font-style: italic;
+    letter-spacing: -0.05em;
     position: absolute;
-    right: -5px;
-    top: -110px;
+    right: -0px;
+    top: -105px;
 }
 
 h1 {


### PR DESCRIPTION
Some colleagues complained it looks not so nice (despite being the normal spacing). 

Drive-by-fix: Add Roboto as slightly better alternative font.

Before:
<img width="936" alt="Screenshot 2023-06-12 at 13 27 12" src="https://github.com/WebKit/Speedometer/assets/129550/ca3c1ff2-3b3f-47ef-83c2-3902a8678c13">

After:
<img width="962" alt="Screenshot 2023-06-12 at 13 27 04" src="https://github.com/WebKit/Speedometer/assets/129550/86b499bf-c857-464f-bf63-51232b2ed801">
