### PR TITLE
Undefine requestIdleCallback in the code mirror test for consistency.

### DIFF
--- a/resources/editors/codemirror.html
+++ b/resources/editors/codemirror.html
@@ -6,6 +6,10 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link rel="stylesheet" href="/style.css" />
         <title>CodeMirror Test</title>
+        <script>
+            window.requestIdleCallback = undefined;
+            window.cancelIdleCallback = undefined;
+        </script>
     </head>
     <body>
         <div id="app">


### PR DESCRIPTION
We can undo this change once Safari / WebKit adds the support for requestIdleCallback.