### PR TITLE
Move the initial glyph cache cost out of the measured part of the perf dashboard workload.

### DIFF
--- a/resources/tentative/perf.webkit.org/public/v3/index.html
+++ b/resources/tentative/perf.webkit.org/public/v3/index.html
@@ -71,10 +71,15 @@ Run tools/bundle-v3-scripts to speed up the load time for production.`);
             const pageShadow = document.querySelector('page-component').component()._shadow;
             return pageShadow.querySelector('chart-pane').component()._shadow.querySelector('.chart-pane');
         }
-        
+
         function getChartCanvas()
         {
             return getChartPane().querySelector('interactive-time-series-chart').component()._shadow.querySelector('canvas');
+        }
+
+        function openCharts()
+        {
+            location.hash = '/charts/?since=1678991819934\u0026paneList=((55-1649-53731881-null-(5-2.5-500))-(55-1407-null-null-(5-2.5-500))-(55-1648-null-null-(5-2.5-500))-(55-1974-null-null-(5-2.5-500)))';
         }
 
         function mockAPIs() {

--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -619,16 +619,18 @@ Suites.push({
 
 Suites.push({
     name: "Perf-Dashboard",
-    url: "tentative/perf.webkit.org/public/v3/#/charts?since=1678991819934&paneList=((55-1649-53731881-null-(5-2.5-500))-(55-1407-null-null-(5-2.5-500))-(55-1648-null-null-(5-2.5-500))-(55-1974-null-null-(5-2.5-500)))",
+    url: "tentative/perf.webkit.org/public/v3/#/charts/?since=1678991819934&paneList=((55-1974-null-null-(5-2.5-500)))",
     tags: ["chart", "webcomponents"],
     async prepare(page) {
         await page.waitForElement("#app-is-ready");
-        page.call("serviceRAF");
+        page.call("startTest");
+        page.callAsync("serviceRAF");
+        await new Promise((resolve) => setTimeout(resolve, 1));
     },
     tests: [
         new BenchmarkTestStep("Render", (page) => {
-            page.call("startTest");
-            page.callAsync("serviceRAF");
+            page.call("openCharts");
+            page.call("serviceRAF");
         }),
         new BenchmarkTestStep("SelectingPoints", (page) => {
             const chartPane = page.callToGetElement("getChartPane");


### PR DESCRIPTION
This makes the benchmark results more consistent when re-running it in the same tab.