### PR TITLE
Make the dotted substep longer by drawing twice

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -135,6 +135,10 @@ class PageElement {
         this.#node.value = value;
     }
 
+    setChecked(bool) {
+        this.#node.checked = bool;
+    }
+
     click() {
         this.#node.click();
     }

--- a/resources/charts/dist/assets/plot-27e82af1.js
+++ b/resources/charts/dist/assets/plot-27e82af1.js
@@ -12270,7 +12270,7 @@ function addDottedBars() {
       label: "← outward          Number of flights          inward →",
       labelAnchor: "center",
       tickFormat: (v) => format$1("~s")(Math.abs(v)),
-      type: "pow",
+      type: dottedGraphAxisType(),
       exponent: 0.2
     },
     marks: [
@@ -12306,10 +12306,16 @@ function airportCountPerGroup() {
 function onGroupSizeInputChange() {
   document.querySelector("#airport-group-size").textContent = airportCountPerGroup();
 }
+function dottedGraphAxisType() {
+  return document.getElementById("dotted-graph-axis-type").checked ? "pow" : "linear";
+}
+function onDottedGraphAxisTypeChange() {
+}
 document.getElementById("prepare").addEventListener("click", prepare);
 document.getElementById("add-stacked-chart-button").addEventListener("click", addStackedBars);
 document.getElementById("add-dotted-chart-button").addEventListener("click", addDottedBars);
 document.getElementById("reset").addEventListener("click", reset);
 document.getElementById("run-all").addEventListener("click", runAllTheThings);
 document.getElementById("airport-group-size-input").addEventListener("input", onGroupSizeInputChange);
+document.getElementById("dotted-graph-axis-type").addEventListener("input", onDottedGraphAxisTypeChange);
 onGroupSizeInputChange();

--- a/resources/charts/dist/observable-plot.html
+++ b/resources/charts/dist/observable-plot.html
@@ -15,7 +15,7 @@
                 min-width: 30px;
             }
         </style>
-      <script type="module" crossorigin src="./assets/plot-37d2a5fb.js"></script>
+      <script type="module" crossorigin src="./assets/plot-27e82af1.js"></script>
       <link rel="modulepreload" crossorigin href="./assets/flights-airports-9a9e6422.js">
     </head>
     <body>
@@ -29,6 +29,10 @@
                 Number of airports to keep in each group:
                 <span id="airport-group-size"></span>
                 <input type="range" id="airport-group-size-input" min="0" max="20" value="6" />
+            </label>
+            <label>
+                <input type="checkbox" id="dotted-graph-axis-type" />
+                Use a 5th root scale
             </label>
         </div>
         <div id="chart"></div>

--- a/resources/charts/observable-plot.html
+++ b/resources/charts/observable-plot.html
@@ -28,6 +28,10 @@
                 <span id="airport-group-size"></span>
                 <input type="range" id="airport-group-size-input" min="0" max="20" value="6" />
             </label>
+            <label>
+                <input type="checkbox" id="dotted-graph-axis-type" />
+                Use a 5th root scale
+            </label>
         </div>
         <div id="chart"></div>
         <script type="module" src="/observable-plot.js"></script>

--- a/resources/charts/observable-plot.js
+++ b/resources/charts/observable-plot.js
@@ -173,7 +173,7 @@ function addDottedBars() {
             label: "← outward          Number of flights          inward →",
             labelAnchor: "center",
             tickFormat: (v) => d3Format("~s")(Math.abs(v)),
-            type: "pow",
+            type: dottedGraphAxisType(),
             exponent: 0.2,
         },
         marks: [
@@ -221,12 +221,26 @@ function onGroupSizeInputChange() {
     }
 }
 
+// This checkbox controls the axis for the dotted graph. We can switch between a
+// linear or a square scale.
+function dottedGraphAxisType() {
+    return document.getElementById("dotted-graph-axis-type").checked ? "pow" : "linear";
+}
+
+function onDottedGraphAxisTypeChange() {
+    if (import.meta.env.DEV) {
+        // In dev mode, redraw everything
+        runAllTheThings();
+    }
+}
+
 document.getElementById("prepare").addEventListener("click", prepare);
 document.getElementById("add-stacked-chart-button").addEventListener("click", addStackedBars);
 document.getElementById("add-dotted-chart-button").addEventListener("click", addDottedBars);
 document.getElementById("reset").addEventListener("click", reset);
 document.getElementById("run-all").addEventListener("click", runAllTheThings);
 document.getElementById("airport-group-size-input").addEventListener("input", onGroupSizeInputChange);
+document.getElementById("dotted-graph-axis-type").addEventListener("input", onDottedGraphAxisTypeChange);
 onGroupSizeInputChange();
 
 if (import.meta.env.DEV)

--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -581,6 +581,10 @@ Suites.push({
         new BenchmarkTestStep("Dotted", (page) => {
             page.querySelector("#reset").click();
             page.querySelector("#add-dotted-chart-button").click();
+            page.layout();
+            page.querySelector("#dotted-graph-axis-type").setChecked(true);
+            page.querySelector("#reset").click();
+            page.querySelector("#add-dotted-chart-button").click();
         }),
     ],
 });


### PR DESCRIPTION
Camillo asked about this in https://github.com/WebKit/Speedometer/pull/220#issuecomment-1589979335

Now the "dotted" graph is done twice, with 2 different settings. This makes it go to the ballpark of 30ms instead of 18ms on my computer. I tested both Chrome and Firefox, the increase looks similar to me.

[deploy preview](https://make-dotted-longer--speedometer-preview.netlify.app/?suite=Charts-Observable-plot)

What do you think @camillobruni @bgrins @flashdesignory @rniwa ?