### PR TITLE
add npm run server to run caching server

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "license": "SEE LICENSE IN LICENSE",
     "scripts": {
         "dev": "http-server ./ -p 7000 -c-1 --cors",
+        "server": "http-server ./ -p 7000 --cors",
         "lint:check": "eslint **/*.mjs",
         "lint:fix": "eslint \"**/*.{js,mjs,jsx,ts}\" --fix",
         "pretty:check": "prettier --check ./",


### PR DESCRIPTION
`npm run server` will now run a local server with caching files.
This is more realistic for local benchmarking, while `npm run dev` keeps on the non-caching behavior which is nicer for developing the benchmark.