### PR TITLE
Simplify the score calculation by replacing 60 / 50 by 1.

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -215,8 +215,7 @@ class PageElement {
 }
 
 function geomeanToScore(geomean) {
-    const correctionFactor = 50; // This factor makes the test score look reasonably fit within 0 to 140.
-    return (60 * 1000) / geomean / correctionFactor;
+    return 1000 / geomean;
 }
 
 // The WarmupSuite is used to make sure all runner helper functions and

--- a/tests/benchmark-runner-tests.mjs
+++ b/tests/benchmark-runner-tests.mjs
@@ -214,7 +214,7 @@ describe("BenchmarkRunner", () => {
                     const total = syncTime + asyncTime;
                     const mean = total / suite.tests.length;
                     const geomean = Math.pow(total, 1 / suite.tests.length);
-                    const score = (60 * 1000) / geomean / 50; // correctionFactor = 50
+                    const score = 1000 / geomean;
 
                     const { total: measuredTotal, mean: measuredMean, geomean: measuredGeomean, score: measuredScore } = runner._measuredValues;
 


### PR DESCRIPTION
This makes the score runs/s, which is pretty neat.