### PR TITLE
Delete duplicated React Complex DOM README

### DIFF
--- a/resources/todomvc/architecture-examples/react-complex/readme.md
+++ b/resources/todomvc/architecture-examples/react-complex/readme.md
@@ -1,1 +1,0 @@
-# Speedometer 3.0: TodoMVC: React Complex


### PR DESCRIPTION
Right now, there is a `resources/todomvc/architecture-examples/react-complex/readme.md` and a `resources/todomvc/architecture-examples/react-complex/README.md`. Deleting the lowercase version.