### PR TITLE
Add complex DOM workloads to tests.mjs disabled by default

### DIFF
--- a/resources/developer-mode.mjs
+++ b/resources/developer-mode.mjs
@@ -186,7 +186,7 @@ function updateURL() {
     // to comma separate only the selected
     const selectedSuites = Suites.filter((suite) => !suite.disabled);
 
-    if (!selectedSuites.length || selectedSuites.length === Suites.length) {
+    if (!selectedSuites.length) {
         url.searchParams.delete("tags");
         url.searchParams.delete("suites");
         url.searchParams.delete("suite");
@@ -202,7 +202,11 @@ function updateURL() {
                 commonTags = new Set(suite.tags.filter((tag) => commonTags.has(tag)));
         }
         if (commonTags.size) {
-            url.searchParams.set("tags", [...commonTags][0]);
+            const tags = [...commonTags][0];
+            if (tags === "default")
+                url.searchParams.delete("tags");
+            else
+                url.searchParams.set("tags", tags);
             url.searchParams.delete("suites");
         } else {
             url.searchParams.delete("tags");

--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -449,6 +449,337 @@ Suites.push({
 });
 
 Suites.push({
+    name: "TodoMVC-JavaScript-ES5-Complex-DOM",
+    url: "todomvc/vanilla-examples/javascript-es5-complex/dist/index.html",
+    tags: ["todomvc"],
+    async prepare(page) {
+        (await page.waitForElement(".new-todo")).focus();
+    },
+    tests: [
+        new BenchmarkTestStep(`Adding${numberOfItemsToAdd}Items`, (page) => {
+            const newTodo = page.querySelector(".new-todo");
+            for (let i = 0; i < numberOfItemsToAdd; i++) {
+                newTodo.setValue(getTodoText("ja", i));
+                newTodo.dispatchEvent("change");
+                newTodo.enter("keypress");
+            }
+        }),
+        new BenchmarkTestStep("CompletingAllItems", (page) => {
+            const checkboxes = page.querySelectorAll(".toggle");
+            for (let i = 0; i < numberOfItemsToAdd; i++)
+                checkboxes[i].click();
+        }),
+        new BenchmarkTestStep("DeletingAllItems", (page) => {
+            const deleteButtons = page.querySelectorAll(".destroy");
+            for (let i = numberOfItemsToAdd - 1; i >= 0; i--)
+                deleteButtons[i].click();
+        }),
+    ],
+});
+
+Suites.push({
+    name: "TodoMVC-JavaScript-ES6-Webpack-Complex-DOM",
+    url: "todomvc/vanilla-examples/javascript-es6-webpack-complex/dist/index.html",
+    tags: ["todomvc"],
+    async prepare(page) {
+        const element = await page.waitForElement(".new-todo");
+        element.focus();
+    },
+    tests: [
+        new BenchmarkTestStep(`Adding${numberOfItemsToAdd}Items`, (page) => {
+            const newTodo = page.querySelector(".new-todo");
+            for (let i = 0; i < numberOfItemsToAdd; i++) {
+                newTodo.setValue(getTodoText("ru", i));
+                newTodo.dispatchEvent("change");
+                newTodo.enter("keypress");
+            }
+        }),
+        new BenchmarkTestStep("CompletingAllItems", (page) => {
+            const checkboxes = page.querySelectorAll(".toggle");
+            for (let i = 0; i < numberOfItemsToAdd; i++)
+                checkboxes[i].click();
+        }),
+        new BenchmarkTestStep("DeletingAllItems", (page) => {
+            const deleteButtons = page.querySelectorAll(".destroy");
+            for (let i = numberOfItemsToAdd - 1; i >= 0; i--)
+                deleteButtons[i].click();
+        }),
+    ],
+});
+
+Suites.push({
+    name: "TodoMVC-WebComponents-Complex-DOM",
+    url: "todomvc/vanilla-examples/javascript-web-components-complex/dist/index.html",
+    tags: ["todomvc", "webcomponents"],
+    async prepare(page) {
+        await page.waitForElement("todo-app");
+    },
+    tests: [
+        new BenchmarkTestStep(`Adding${numberOfItemsToAdd}Items`, (page) => {
+            const input = page.querySelector(".new-todo-input", ["todo-app", "todo-topbar"]);
+            for (let i = 0; i < numberOfItemsToAdd; i++) {
+                input.setValue(getTodoText(defaultLanguage, i));
+                input.dispatchEvent("input");
+                input.enter("keyup");
+            }
+        }),
+        new BenchmarkTestStep("CompletingAllItems", (page) => {
+            const items = page.querySelectorAll("todo-item", ["todo-app", "todo-list"]);
+            for (let i = 0; i < numberOfItemsToAdd; i++) {
+                const item = items[i].querySelectorInShadowRoot(".toggle-todo-input");
+                item.click();
+            }
+        }),
+        new BenchmarkTestStep("DeletingAllItems", (page) => {
+            const items = page.querySelectorAll("todo-item", ["todo-app", "todo-list"]);
+            for (let i = 0; i < numberOfItemsToAdd; i++) {
+                const item = items[i].querySelectorInShadowRoot(".remove-todo-button");
+                item.click();
+            }
+        }),
+    ],
+});
+
+Suites.push({
+    name: "TodoMVC-React-Redux-Complex-DOM",
+    url: "todomvc/architecture-examples/react-redux-complex/dist/index.html",
+    tags: ["todomvc"],
+    async prepare(page) {
+        const element = await page.waitForElement(".new-todo");
+        element.focus();
+    },
+    tests: [
+        new BenchmarkTestStep(`Adding${numberOfItemsToAdd}Items`, (page) => {
+            const newTodo = page.querySelector(".new-todo");
+            for (let i = 0; i < numberOfItemsToAdd; i++) {
+                newTodo.setValue(getTodoText(defaultLanguage, i));
+                newTodo.enter("keydown");
+            }
+        }),
+        new BenchmarkTestStep("CompletingAllItems", (page) => {
+            const checkboxes = page.querySelectorAll(".toggle");
+            for (let i = 0; i < numberOfItemsToAdd; i++)
+                checkboxes[i].click();
+        }),
+        new BenchmarkTestStep("DeletingAllItems", (page) => {
+            const deleteButtons = page.querySelectorAll(".destroy");
+            for (let i = numberOfItemsToAdd - 1; i >= 0; i--)
+                deleteButtons[i].click();
+        }),
+    ],
+});
+
+Suites.push({
+    name: "TodoMVC-Backbone-Complex-DOM",
+    url: "todomvc/architecture-examples/backbone-complex/dist/index.html",
+    tags: ["todomvc"],
+    async prepare(page) {
+        await page.waitForElement("#appIsReady");
+        const newTodo = page.querySelector(".new-todo");
+        newTodo.focus();
+    },
+    tests: [
+        new BenchmarkTestStep(`Adding${numberOfItemsToAdd}Items`, (page) => {
+            const newTodo = page.querySelector(".new-todo");
+            for (let i = 0; i < numberOfItemsToAdd; i++) {
+                newTodo.setValue(getTodoText(defaultLanguage, i));
+                newTodo.dispatchEvent("change");
+                newTodo.enter("keypress");
+            }
+        }),
+        new BenchmarkTestStep("CompletingAllItems", (page) => {
+            const checkboxes = page.querySelectorAll(".toggle");
+            for (let i = 0; i < numberOfItemsToAdd; i++)
+                checkboxes[i].click();
+        }),
+        new BenchmarkTestStep("DeletingAllItems", (page) => {
+            const deleteButtons = page.querySelectorAll(".destroy");
+            for (let i = numberOfItemsToAdd - 1; i >= 0; i--)
+                deleteButtons[i].click();
+        }),
+    ],
+});
+
+Suites.push({
+    name: "TodoMVC-Angular-Complex-DOM",
+    url: "todomvc/architecture-examples/angular-complex/dist/index.html",
+    tags: ["todomvc"],
+    async prepare(page) {
+        const element = await page.waitForElement(".new-todo");
+        element.focus();
+    },
+    tests: [
+        new BenchmarkTestStep(`Adding${numberOfItemsToAdd}Items`, (page) => {
+            const newTodo = page.querySelector(".new-todo");
+            for (let i = 0; i < numberOfItemsToAdd; i++) {
+                newTodo.setValue(getTodoText(defaultLanguage, i));
+                newTodo.dispatchEvent("input");
+                newTodo.enter("keyup");
+            }
+        }),
+        new BenchmarkTestStep("CompletingAllItems", (page) => {
+            const checkboxes = page.querySelectorAll(".toggle");
+            for (let i = 0; i < numberOfItemsToAdd; i++)
+                checkboxes[i].click();
+        }),
+        new BenchmarkTestStep("DeletingAllItems", (page) => {
+            const deleteButtons = page.querySelectorAll(".destroy");
+            for (let i = numberOfItemsToAdd - 1; i >= 0; i--)
+                deleteButtons[i].click();
+        }),
+    ],
+});
+
+Suites.push({
+    name: "TodoMVC-Vue-Complex-DOM",
+    url: "todomvc/architecture-examples/vue-complex/dist/index.html",
+    tags: ["todomvc"],
+    async prepare(page) {
+        const element = await page.waitForElement(".new-todo");
+        element.focus();
+    },
+    tests: [
+        new BenchmarkTestStep(`Adding${numberOfItemsToAdd}Items`, (page) => {
+            const newTodo = page.querySelector(".new-todo");
+            for (let i = 0; i < numberOfItemsToAdd; i++) {
+                newTodo.setValue(getTodoText(defaultLanguage, i));
+                newTodo.dispatchEvent("input");
+                newTodo.enter("keyup");
+            }
+        }),
+        new BenchmarkTestStep("CompletingAllItems", (page) => {
+            const checkboxes = page.querySelectorAll(".toggle");
+            for (let i = 0; i < numberOfItemsToAdd; i++)
+                checkboxes[i].click();
+        }),
+        new BenchmarkTestStep("DeletingAllItems", (page) => {
+            const deleteButtons = page.querySelectorAll(".destroy");
+            for (let i = numberOfItemsToAdd - 1; i >= 0; i--)
+                deleteButtons[i].click();
+        }),
+    ],
+});
+
+Suites.push({
+    name: "TodoMVC-jQuery-Complex-DOM",
+    url: "todomvc/architecture-examples/jquery-complex/dist/index.html",
+    tags: ["todomvc"],
+    async prepare(page) {
+        await page.waitForElement("#appIsReady");
+        const newTodo = page.getElementById("new-todo");
+        newTodo.focus();
+    },
+    tests: [
+        new BenchmarkTestStep(`Adding${numberOfItemsToAdd}Items`, (page) => {
+            const newTodo = page.querySelector(".new-todo");
+            for (let i = 0; i < numberOfItemsToAdd; i++) {
+                newTodo.setValue(getTodoText(defaultLanguage, i));
+                newTodo.enter("keyup");
+            }
+        }),
+        new BenchmarkTestStep("CompletingAllItems", (page) => {
+            const checkboxes = page.querySelectorAll(".toggle");
+            for (let i = 0; i < numberOfItemsToAdd; i++)
+                checkboxes[i].click();
+        }),
+        new BenchmarkTestStep("DeletingAllItems", (page) => {
+            for (let i = numberOfItemsToAdd - 1; i >= 0; i--)
+                page.querySelector(".destroy").click();
+        }),
+    ],
+});
+
+Suites.push({
+    name: "TodoMVC-Preact-Complex-DOM",
+    url: "todomvc/architecture-examples/preact-complex/dist/index.html#/home",
+    tags: ["todomvc"],
+    async prepare(page) {
+        const element = await page.waitForElement(".new-todo");
+        element.focus();
+    },
+    tests: [
+        new BenchmarkTestStep(`Adding${numberOfItemsToAdd}Items`, (page) => {
+            const newTodo = page.querySelector(".new-todo");
+            for (let i = 0; i < numberOfItemsToAdd; i++) {
+                newTodo.setValue(getTodoText(defaultLanguage, i));
+                newTodo.enter("keydown");
+            }
+        }),
+        new BenchmarkTestStep("CompletingAllItems", (page) => {
+            const checkboxes = page.querySelectorAll(".toggle");
+            for (let i = 0; i < numberOfItemsToAdd; i++)
+                checkboxes[i].click();
+        }),
+        new BenchmarkTestStep("DeletingAllItems", (page) => {
+            const deleteButtons = page.querySelectorAll(".destroy");
+            for (let i = numberOfItemsToAdd - 1; i >= 0; i--)
+                deleteButtons[i].click();
+        }),
+    ],
+});
+
+Suites.push({
+    name: "TodoMVC-Svelte-Complex-DOM",
+    url: "todomvc/architecture-examples/svelte-complex/dist/index.html",
+    tags: ["todomvc"],
+    async prepare(page) {
+        const element = await page.waitForElement(".new-todo");
+        element.focus();
+    },
+    tests: [
+        new BenchmarkTestStep(`Adding${numberOfItemsToAdd}Items`, (page) => {
+            const newTodo = page.querySelector(".new-todo");
+            for (let i = 0; i < numberOfItemsToAdd; i++) {
+                newTodo.setValue(getTodoText(defaultLanguage, i));
+                newTodo.enter("keydown");
+            }
+        }),
+        new BenchmarkTestStep("CompletingAllItems", (page) => {
+            const checkboxes = page.querySelectorAll(".toggle");
+            for (let i = 0; i < numberOfItemsToAdd; i++)
+                checkboxes[i].click();
+        }),
+        new BenchmarkTestStep("DeletingAllItems", (page) => {
+            const deleteButtons = page.querySelectorAll(".destroy");
+            for (let i = numberOfItemsToAdd - 1; i >= 0; i--)
+                deleteButtons[i].click();
+        }),
+    ],
+});
+
+Suites.push({
+    name: "TodoMVC-Lit-Complex-DOM",
+    url: "todomvc/architecture-examples/lit-complex/dist/index.html",
+    tags: ["todomvc", "webcomponents"],
+    async prepare(page) {
+        await page.waitForElement("todo-app");
+    },
+    tests: [
+        new BenchmarkTestStep(`Adding${numberOfItemsToAdd}Items`, (page) => {
+            const newTodo = page.querySelector(".new-todo", ["todo-app", "todo-form"]);
+            for (let i = 0; i < numberOfItemsToAdd; i++) {
+                newTodo.setValue(getTodoText(defaultLanguage, i));
+                newTodo.enter("keydown");
+            }
+        }),
+        new BenchmarkTestStep("CompletingAllItems", (page) => {
+            const todoItems = page.querySelectorAll("todo-item", ["todo-app", "todo-list"]);
+            for (let i = 0; i < numberOfItemsToAdd; i++) {
+                const checkbox = todoItems[i].querySelectorInShadowRoot(".toggle");
+                checkbox.click();
+            }
+        }),
+        new BenchmarkTestStep("DeletingAllItems", (page) => {
+            const todoItems = page.querySelectorAll("todo-item", ["todo-app", "todo-list"]);
+            for (let i = 0; i < numberOfItemsToAdd; i++) {
+                const deleteButton = todoItems[i].querySelectorInShadowRoot(".destroy");
+                deleteButton.click();
+            }
+        }),
+    ],
+});
+
+Suites.push({
     name: "NewsSite-Next",
     url: "newssite/news-next/dist/index.html#/home",
     tags: ["newssite", "language"],

--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -535,7 +535,7 @@ Suites.push({
         }),
         new BenchmarkTestStep("DeletingAllItems", (page) => {
             const items = page.querySelectorAll("todo-item", ["todo-app", "todo-list"]);
-            for (let i = 0; i < numberOfItemsToAdd; i++) {
+            for (let i = numberOfItemsToAdd - 1; i >= 0; i--) {
                 const item = items[i].querySelectorInShadowRoot(".remove-todo-button");
                 item.click();
             }
@@ -782,7 +782,7 @@ Suites.push({
         }),
         new BenchmarkTestStep("DeletingAllItems", (page) => {
             const todoItems = page.querySelectorAll("todo-item", ["todo-app", "todo-list"]);
-            for (let i = 0; i < numberOfItemsToAdd; i++) {
+            for (let i = numberOfItemsToAdd - 1; i >= 0; i--) {
                 const deleteButton = todoItems[i].querySelectorInShadowRoot(".destroy");
                 deleteButton.click();
             }

--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -182,7 +182,7 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-React-Complex-DOM",
     url: "todomvc/architecture-examples/react-complex/dist/index.html#/home",
-    tags: ["todomvc", "complex"],
+    tags: ["todomvc", "complex", "complex-default"],
     async prepare(page) {
         const element = await page.waitForElement(".new-todo");
         element.focus();
@@ -451,7 +451,8 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-JavaScript-ES5-Complex-DOM",
     url: "todomvc/vanilla-examples/javascript-es5-complex/dist/index.html",
-    tags: ["todomvc"],
+    tags: ["todomvc", "complex"],
+    disabled: true,
     async prepare(page) {
         (await page.waitForElement(".new-todo")).focus();
     },
@@ -480,7 +481,8 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-JavaScript-ES6-Webpack-Complex-DOM",
     url: "todomvc/vanilla-examples/javascript-es6-webpack-complex/dist/index.html",
-    tags: ["todomvc"],
+    tags: ["todomvc", "complex", "complex-default"],
+    disabled: true,
     async prepare(page) {
         const element = await page.waitForElement(".new-todo");
         element.focus();
@@ -510,7 +512,8 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-WebComponents-Complex-DOM",
     url: "todomvc/vanilla-examples/javascript-web-components-complex/dist/index.html",
-    tags: ["todomvc", "webcomponents"],
+    tags: ["todomvc", "webcomponents", "complex"],
+    disabled: true,
     async prepare(page) {
         await page.waitForElement("todo-app");
     },
@@ -543,7 +546,8 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-React-Redux-Complex-DOM",
     url: "todomvc/architecture-examples/react-redux-complex/dist/index.html",
-    tags: ["todomvc"],
+    tags: ["todomvc", "complex"],
+    disabled: true,
     async prepare(page) {
         const element = await page.waitForElement(".new-todo");
         element.focus();
@@ -572,7 +576,8 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-Backbone-Complex-DOM",
     url: "todomvc/architecture-examples/backbone-complex/dist/index.html",
-    tags: ["todomvc"],
+    tags: ["todomvc", "complex"],
+    disabled: true,
     async prepare(page) {
         await page.waitForElement("#appIsReady");
         const newTodo = page.querySelector(".new-todo");
@@ -603,7 +608,8 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-Angular-Complex-DOM",
     url: "todomvc/architecture-examples/angular-complex/dist/index.html",
-    tags: ["todomvc"],
+    tags: ["todomvc", "complex", "complex-default"],
+    disabled: true,
     async prepare(page) {
         const element = await page.waitForElement(".new-todo");
         element.focus();
@@ -633,7 +639,8 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-Vue-Complex-DOM",
     url: "todomvc/architecture-examples/vue-complex/dist/index.html",
-    tags: ["todomvc"],
+    tags: ["todomvc", "complex", "complex-default"],
+    disabled: true,
     async prepare(page) {
         const element = await page.waitForElement(".new-todo");
         element.focus();
@@ -663,7 +670,8 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-jQuery-Complex-DOM",
     url: "todomvc/architecture-examples/jquery-complex/dist/index.html",
-    tags: ["todomvc"],
+    tags: ["todomvc", "complex"],
+    disabled: true,
     async prepare(page) {
         await page.waitForElement("#appIsReady");
         const newTodo = page.getElementById("new-todo");
@@ -692,7 +700,8 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-Preact-Complex-DOM",
     url: "todomvc/architecture-examples/preact-complex/dist/index.html#/home",
-    tags: ["todomvc"],
+    tags: ["todomvc", "complex", "complex-default"],
+    disabled: true,
     async prepare(page) {
         const element = await page.waitForElement(".new-todo");
         element.focus();
@@ -721,7 +730,8 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-Svelte-Complex-DOM",
     url: "todomvc/architecture-examples/svelte-complex/dist/index.html",
-    tags: ["todomvc"],
+    tags: ["todomvc", "complex", "complex-default"],
+    disabled: true,
     async prepare(page) {
         const element = await page.waitForElement(".new-todo");
         element.focus();
@@ -750,7 +760,8 @@ Suites.push({
 Suites.push({
     name: "TodoMVC-Lit-Complex-DOM",
     url: "todomvc/architecture-examples/lit-complex/dist/index.html",
-    tags: ["todomvc", "webcomponents"],
+    tags: ["todomvc", "webcomponents", "complex", "complex-default"],
+    disabled: true,
     async prepare(page) {
         await page.waitForElement("todo-app");
     },
@@ -1033,6 +1044,8 @@ Suites.forEach((suite) => {
         suite.tags = [];
     if (suite.url.startsWith("tentative/"))
         suite.tags.unshift("all", "tentative");
+    else if (suite.disabled)
+        suite.tags.unshift("all");
     else
         suite.tags.unshift("all", "default");
     Object.freeze(suite.tags);


### PR DESCRIPTION
This PR:

- Adds all the complex DOM workloads to `tests.mjs` under the `complex` tag.
- Sets the disabled flag to `true` for all complex-DOM variations except React-Complex-DOM.
- Adds a new tag `complex-default` for the workloads that the group agreed should eventually be enabled by default.
- Makes a small logic change to not add the `default` tag for the disabled tests.

[Hosted version](https://lpardosixtosms.github.io/Speedometer)