### PR TITLE
todomvc web-components, change title, id & completed attributes on item component

### DIFF
--- a/resources/todomvc/vanilla-examples/javascript-web-components/dist/components/todo-item/todo-item.component.js
+++ b/resources/todomvc/vanilla-examples/javascript-web-components/dist/components/todo-item/todo-item.component.js
@@ -7,18 +7,18 @@ import itemStyles from "../../styles/todo-item.constructable.js";
 
 class TodoItem extends HTMLElement {
     static get observedAttributes() {
-        return ["item-id", "item-title", "item-completed"];
+        return ["itemid", "itemtitle", "itemcompleted"];
     }
 
     constructor() {
         super();
 
-        // Renamed this.id to this["item-id"] and this.title to this["item-title"].
+        // Renamed this.id to this.itemid and this.title to this.itemtitle.
         // When the component assigns to this.id or this.title, this causes the browser's implementation of the existing setters to run, which convert these property sets into internal setAttribute calls. This can have surprising consequences.
         // [Issue]: https://github.com/WebKit/Speedometer/issues/313
-        this["item-id"] = "";
-        this["item-title"] = "Todo Item";
-        this["item-completed"] = "false";
+        this.itemid = "";
+        this.itemtitle = "Todo Item";
+        this.itemcompleted = "false";
 
         const node = document.importNode(template.content, true);
         this.item = node.querySelector(".todo-item");
@@ -54,18 +54,18 @@ class TodoItem extends HTMLElement {
     update(...args) {
         args.forEach((argument) => {
             switch (argument) {
-                case "item-id":
-                    if (this["item-id"] !== undefined)
-                        this.item.id = `todo-item-${this["item-id"]}`;
+                case "itemid":
+                    if (this.itemid !== undefined)
+                        this.item.id = `todo-item-${this.itemid}`;
                     break;
-                case "item-title":
-                    if (this["item-title"] !== undefined) {
-                        this.todoText.textContent = this["item-title"];
-                        this.editInput.value = this["item-title"];
+                case "itemtitle":
+                    if (this.itemtitle !== undefined) {
+                        this.todoText.textContent = this.itemtitle;
+                        this.editInput.value = this.itemtitle;
                     }
                     break;
-                case "item-completed":
-                    this.toggleInput.checked = this["item-completed"] === "true" ? true : false;
+                case "itemcompleted":
+                    this.toggleInput.checked = this.itemcompleted === "true" ? true : false;
                     break;
             }
         });
@@ -73,7 +73,7 @@ class TodoItem extends HTMLElement {
 
     startEdit() {
         this.item.classList.add("editing");
-        this.editInput.value = this["item-title"];
+        this.editInput.value = this.itemtitle;
         this.editInput.focus();
     }
 
@@ -88,11 +88,11 @@ class TodoItem extends HTMLElement {
     toggleItem() {
         // The todo-list checks the "completed" attribute to filter based on route
         // (therefore the completed state needs to already be updated before the check)
-        this.setAttribute("item-completed", this.toggleInput.checked);
+        this.setAttribute("itemcompleted", this.toggleInput.checked);
 
         this.dispatchEvent(
             new CustomEvent("toggle-item", {
-                detail: { id: this["item-id"], completed: this.toggleInput.checked },
+                detail: { id: this.itemid, completed: this.toggleInput.checked },
                 bubbles: true,
             })
         );
@@ -103,7 +103,7 @@ class TodoItem extends HTMLElement {
         // (therefore the removal has to happen after the list is updated)
         this.dispatchEvent(
             new CustomEvent("remove-item", {
-                detail: { id: this["item-id"] },
+                detail: { id: this.itemid },
                 bubbles: true,
             })
         );
@@ -111,14 +111,14 @@ class TodoItem extends HTMLElement {
     }
 
     updateItem(event) {
-        if (event.target.value !== this["item-title"]) {
+        if (event.target.value !== this.itemtitle) {
             if (!event.target.value.length) {
                 this.removeItem();
             } else {
-                this.setAttribute("item-title", event.target.value);
+                this.setAttribute("itemtitle", event.target.value);
                 this.dispatchEvent(
                     new CustomEvent("update-item", {
-                        detail: { id: this["item-id"], title: event.target.value },
+                        detail: { id: this.itemid, title: event.target.value },
                         bubbles: true,
                     })
                 );
@@ -156,7 +156,7 @@ class TodoItem extends HTMLElement {
     }
 
     connectedCallback() {
-        this.update("item-id", "item-title", "item-completed");
+        this.update("itemid", "itemtitle", "itemcompleted");
 
         this.keysListeners.push(
             useKeyListener({

--- a/resources/todomvc/vanilla-examples/javascript-web-components/dist/components/todo-item/todo-item.component.js
+++ b/resources/todomvc/vanilla-examples/javascript-web-components/dist/components/todo-item/todo-item.component.js
@@ -7,15 +7,18 @@ import itemStyles from "../../styles/todo-item.constructable.js";
 
 class TodoItem extends HTMLElement {
     static get observedAttributes() {
-        return ["id", "title", "completed"];
+        return ["item-id", "item-title", "item-completed"];
     }
 
     constructor() {
         super();
 
-        this.id = "";
-        this.title = "Todo Item";
-        this.completed = "false";
+        // Renamed this.id to this["item-id"] and this.title to this["item-title"].
+        // When the component assigns to this.id or this.title, this causes the browser's implementation of the existing setters to run, which convert these property sets into internal setAttribute calls. This can have surprising consequences.
+        // [Issue]: https://github.com/WebKit/Speedometer/issues/313
+        this["item-id"] = "";
+        this["item-title"] = "Todo Item";
+        this["item-completed"] = "false";
 
         const node = document.importNode(template.content, true);
         this.item = node.querySelector(".todo-item");
@@ -51,18 +54,18 @@ class TodoItem extends HTMLElement {
     update(...args) {
         args.forEach((argument) => {
             switch (argument) {
-                case "id":
-                    if (this.id !== undefined)
-                        this.item.id = `todo-item-${this.id}`;
+                case "item-id":
+                    if (this["item-id"] !== undefined)
+                        this.item.id = `todo-item-${this["item-id"]}`;
                     break;
-                case "title":
-                    if (this.title !== undefined) {
-                        this.todoText.textContent = this.title;
-                        this.editInput.value = this.title;
+                case "item-title":
+                    if (this["item-title"] !== undefined) {
+                        this.todoText.textContent = this["item-title"];
+                        this.editInput.value = this["item-title"];
                     }
                     break;
-                case "completed":
-                    this.toggleInput.checked = this.completed === "true" ? true : false;
+                case "item-completed":
+                    this.toggleInput.checked = this["item-completed"] === "true" ? true : false;
                     break;
             }
         });
@@ -70,7 +73,7 @@ class TodoItem extends HTMLElement {
 
     startEdit() {
         this.item.classList.add("editing");
-        this.editInput.value = this.title;
+        this.editInput.value = this["item-title"];
         this.editInput.focus();
     }
 
@@ -85,11 +88,11 @@ class TodoItem extends HTMLElement {
     toggleItem() {
         // The todo-list checks the "completed" attribute to filter based on route
         // (therefore the completed state needs to already be updated before the check)
-        this.setAttribute("completed", this.toggleInput.checked);
+        this.setAttribute("item-completed", this.toggleInput.checked);
 
         this.dispatchEvent(
             new CustomEvent("toggle-item", {
-                detail: { id: this.id, completed: this.toggleInput.checked },
+                detail: { id: this["item-id"], completed: this.toggleInput.checked },
                 bubbles: true,
             })
         );
@@ -100,7 +103,7 @@ class TodoItem extends HTMLElement {
         // (therefore the removal has to happen after the list is updated)
         this.dispatchEvent(
             new CustomEvent("remove-item", {
-                detail: { id: this.id },
+                detail: { id: this["item-id"] },
                 bubbles: true,
             })
         );
@@ -108,14 +111,14 @@ class TodoItem extends HTMLElement {
     }
 
     updateItem(event) {
-        if (event.target.value !== this.title) {
+        if (event.target.value !== this["item-title"]) {
             if (!event.target.value.length) {
                 this.removeItem();
             } else {
-                this.setAttribute("title", event.target.value);
+                this.setAttribute("item-title", event.target.value);
                 this.dispatchEvent(
                     new CustomEvent("update-item", {
-                        detail: { id: this.id, title: event.target.value },
+                        detail: { id: this["item-id"], title: event.target.value },
                         bubbles: true,
                     })
                 );
@@ -153,7 +156,7 @@ class TodoItem extends HTMLElement {
     }
 
     connectedCallback() {
-        this.update("id", "title", "completed");
+        this.update("item-id", "item-title", "item-completed");
 
         this.keysListeners.push(
             useKeyListener({

--- a/resources/todomvc/vanilla-examples/javascript-web-components/dist/components/todo-list/todo-list.component.js
+++ b/resources/todomvc/vanilla-examples/javascript-web-components/dist/components/todo-list/todo-list.component.js
@@ -33,8 +33,12 @@ class TodoList extends HTMLElement {
     }
 
     addItem(entry) {
+        const { id, title, completed } = entry;
         const element = new TodoItem();
-        Object.keys(entry).forEach((key) => element.setAttribute(key, entry[key]));
+
+        element.setAttribute("item-id", id);
+        element.setAttribute("item-title", title);
+        element.setAttribute("item-completed", completed);
 
         const elementIndex = this.#elements.length;
         this.#elements.push(element);
@@ -48,18 +52,18 @@ class TodoList extends HTMLElement {
 
     removeCompletedItems() {
         this.#elements = this.#elements.filter((element) => {
-            if (element.completed === "true")
+            if (element["item-completed"] === "true")
                 element.removeItem();
 
-            return element.completed === "false";
+            return element["item-completed"] === "false";
         });
     }
 
     toggleItems(completed) {
         this.#elements.forEach((element) => {
-            if (completed && element.completed === "false")
+            if (completed && element["item-completed"] === "false")
                 element.toggleInput.click();
-            else if (!completed && element.completed === "true")
+            else if (!completed && element["item-completed"] === "true")
                 element.toggleInput.click();
         });
     }
@@ -74,10 +78,10 @@ class TodoList extends HTMLElement {
     updateView(element) {
         switch (this.#route) {
             case "completed":
-                element.style.display = element.completed === "true" ? "block" : "none";
+                element.style.display = element["item-completed"] === "true" ? "block" : "none";
                 break;
             case "active":
-                element.style.display = element.completed === "true" ? "none" : "block";
+                element.style.display = element["item-completed"] === "true" ? "none" : "block";
                 break;
             default:
                 element.style.display = "block";
@@ -92,7 +96,7 @@ class TodoList extends HTMLElement {
             case "toggle-item":
             case "add-item":
                 this.#elements.forEach((element) => {
-                    if (element.id === id)
+                    if (element["item-id"] === id)
                         this.updateView(element);
                 });
                 break;

--- a/resources/todomvc/vanilla-examples/javascript-web-components/dist/components/todo-list/todo-list.component.js
+++ b/resources/todomvc/vanilla-examples/javascript-web-components/dist/components/todo-list/todo-list.component.js
@@ -36,9 +36,9 @@ class TodoList extends HTMLElement {
         const { id, title, completed } = entry;
         const element = new TodoItem();
 
-        element.setAttribute("item-id", id);
-        element.setAttribute("item-title", title);
-        element.setAttribute("item-completed", completed);
+        element.setAttribute("itemid", id);
+        element.setAttribute("itemtitle", title);
+        element.setAttribute("itemcompleted", completed);
 
         const elementIndex = this.#elements.length;
         this.#elements.push(element);
@@ -52,18 +52,18 @@ class TodoList extends HTMLElement {
 
     removeCompletedItems() {
         this.#elements = this.#elements.filter((element) => {
-            if (element["item-completed"] === "true")
+            if (element.itemcompleted === "true")
                 element.removeItem();
 
-            return element["item-completed"] === "false";
+            return element.itemcompleted === "false";
         });
     }
 
     toggleItems(completed) {
         this.#elements.forEach((element) => {
-            if (completed && element["item-completed"] === "false")
+            if (completed && element.itemcompleted === "false")
                 element.toggleInput.click();
-            else if (!completed && element["item-completed"] === "true")
+            else if (!completed && element.itemcompleted === "true")
                 element.toggleInput.click();
         });
     }
@@ -78,10 +78,10 @@ class TodoList extends HTMLElement {
     updateView(element) {
         switch (this.#route) {
             case "completed":
-                element.style.display = element["item-completed"] === "true" ? "block" : "none";
+                element.style.display = element.itemcompleted === "true" ? "block" : "none";
                 break;
             case "active":
-                element.style.display = element["item-completed"] === "true" ? "none" : "block";
+                element.style.display = element.itemcompleted === "true" ? "none" : "block";
                 break;
             default:
                 element.style.display = "block";
@@ -96,13 +96,12 @@ class TodoList extends HTMLElement {
             case "toggle-item":
             case "add-item":
                 this.#elements.forEach((element) => {
-                    if (element["item-id"] === id)
+                    if (element.itemid === id)
                         this.updateView(element);
                 });
                 break;
             case "remove-item":
-                this.#elements = this.#elements.filter((element) => element.id !== id);
-
+                this.#elements = this.#elements.filter((element) => element.itemid !== id);
                 break;
         }
     }

--- a/resources/todomvc/vanilla-examples/javascript-web-components/src/components/todo-item/todo-item.component.js
+++ b/resources/todomvc/vanilla-examples/javascript-web-components/src/components/todo-item/todo-item.component.js
@@ -7,18 +7,18 @@ import itemStyles from "../../../node_modules/todomvc-css/dist/todo-item.constru
 
 class TodoItem extends HTMLElement {
     static get observedAttributes() {
-        return ["item-id", "item-title", "item-completed"];
+        return ["itemid", "itemtitle", "itemcompleted"];
     }
 
     constructor() {
         super();
 
-        // Renamed this.id to this["item-id"] and this.title to this["item-title"].
+        // Renamed this.id to this.itemid and this.title to this.itemtitle.
         // When the component assigns to this.id or this.title, this causes the browser's implementation of the existing setters to run, which convert these property sets into internal setAttribute calls. This can have surprising consequences.
         // [Issue]: https://github.com/WebKit/Speedometer/issues/313
-        this["item-id"] = "";
-        this["item-title"] = "Todo Item";
-        this["item-completed"] = "false";
+        this.itemid = "";
+        this.itemtitle = "Todo Item";
+        this.itemcompleted = "false";
 
         const node = document.importNode(template.content, true);
         this.item = node.querySelector(".todo-item");
@@ -54,18 +54,18 @@ class TodoItem extends HTMLElement {
     update(...args) {
         args.forEach((argument) => {
             switch (argument) {
-                case "item-id":
-                    if (this["item-id"] !== undefined)
-                        this.item.id = `todo-item-${this["item-id"]}`;
+                case "itemid":
+                    if (this.itemid !== undefined)
+                        this.item.id = `todo-item-${this.itemid}`;
                     break;
-                case "item-title":
-                    if (this["item-title"] !== undefined) {
-                        this.todoText.textContent = this["item-title"];
-                        this.editInput.value = this["item-title"];
+                case "itemtitle":
+                    if (this.itemtitle !== undefined) {
+                        this.todoText.textContent = this.itemtitle;
+                        this.editInput.value = this.itemtitle;
                     }
                     break;
-                case "item-completed":
-                    this.toggleInput.checked = this["item-completed"] === "true" ? true : false;
+                case "itemcompleted":
+                    this.toggleInput.checked = this.itemcompleted === "true" ? true : false;
                     break;
             }
         });
@@ -73,7 +73,7 @@ class TodoItem extends HTMLElement {
 
     startEdit() {
         this.item.classList.add("editing");
-        this.editInput.value = this["item-title"];
+        this.editInput.value = this.itemtitle;
         this.editInput.focus();
     }
 
@@ -88,11 +88,11 @@ class TodoItem extends HTMLElement {
     toggleItem() {
         // The todo-list checks the "completed" attribute to filter based on route
         // (therefore the completed state needs to already be updated before the check)
-        this.setAttribute("item-completed", this.toggleInput.checked);
+        this.setAttribute("itemcompleted", this.toggleInput.checked);
 
         this.dispatchEvent(
             new CustomEvent("toggle-item", {
-                detail: { id: this["item-id"], completed: this.toggleInput.checked },
+                detail: { id: this.itemid, completed: this.toggleInput.checked },
                 bubbles: true,
             })
         );
@@ -103,7 +103,7 @@ class TodoItem extends HTMLElement {
         // (therefore the removal has to happen after the list is updated)
         this.dispatchEvent(
             new CustomEvent("remove-item", {
-                detail: { id: this["item-id"] },
+                detail: { id: this.itemid },
                 bubbles: true,
             })
         );
@@ -111,14 +111,14 @@ class TodoItem extends HTMLElement {
     }
 
     updateItem(event) {
-        if (event.target.value !== this["item-title"]) {
+        if (event.target.value !== this.itemtitle) {
             if (!event.target.value.length) {
                 this.removeItem();
             } else {
-                this.setAttribute("item-title", event.target.value);
+                this.setAttribute("itemtitle", event.target.value);
                 this.dispatchEvent(
                     new CustomEvent("update-item", {
-                        detail: { id: this["item-id"], title: event.target.value },
+                        detail: { id: this.itemid, title: event.target.value },
                         bubbles: true,
                     })
                 );
@@ -156,7 +156,7 @@ class TodoItem extends HTMLElement {
     }
 
     connectedCallback() {
-        this.update("item-id", "item-title", "item-completed");
+        this.update("itemid", "itemtitle", "itemcompleted");
 
         this.keysListeners.push(
             useKeyListener({

--- a/resources/todomvc/vanilla-examples/javascript-web-components/src/components/todo-item/todo-item.component.js
+++ b/resources/todomvc/vanilla-examples/javascript-web-components/src/components/todo-item/todo-item.component.js
@@ -7,15 +7,18 @@ import itemStyles from "../../../node_modules/todomvc-css/dist/todo-item.constru
 
 class TodoItem extends HTMLElement {
     static get observedAttributes() {
-        return ["id", "title", "completed"];
+        return ["item-id", "item-title", "item-completed"];
     }
 
     constructor() {
         super();
 
-        this.id = "";
-        this.title = "Todo Item";
-        this.completed = "false";
+        // Renamed this.id to this["item-id"] and this.title to this["item-title"].
+        // When the component assigns to this.id or this.title, this causes the browser's implementation of the existing setters to run, which convert these property sets into internal setAttribute calls. This can have surprising consequences.
+        // [Issue]: https://github.com/WebKit/Speedometer/issues/313
+        this["item-id"] = "";
+        this["item-title"] = "Todo Item";
+        this["item-completed"] = "false";
 
         const node = document.importNode(template.content, true);
         this.item = node.querySelector(".todo-item");
@@ -51,18 +54,18 @@ class TodoItem extends HTMLElement {
     update(...args) {
         args.forEach((argument) => {
             switch (argument) {
-                case "id":
-                    if (this.id !== undefined)
-                        this.item.id = `todo-item-${this.id}`;
+                case "item-id":
+                    if (this["item-id"] !== undefined)
+                        this.item.id = `todo-item-${this["item-id"]}`;
                     break;
-                case "title":
-                    if (this.title !== undefined) {
-                        this.todoText.textContent = this.title;
-                        this.editInput.value = this.title;
+                case "item-title":
+                    if (this["item-title"] !== undefined) {
+                        this.todoText.textContent = this["item-title"];
+                        this.editInput.value = this["item-title"];
                     }
                     break;
-                case "completed":
-                    this.toggleInput.checked = this.completed === "true" ? true : false;
+                case "item-completed":
+                    this.toggleInput.checked = this["item-completed"] === "true" ? true : false;
                     break;
             }
         });
@@ -70,7 +73,7 @@ class TodoItem extends HTMLElement {
 
     startEdit() {
         this.item.classList.add("editing");
-        this.editInput.value = this.title;
+        this.editInput.value = this["item-title"];
         this.editInput.focus();
     }
 
@@ -85,11 +88,11 @@ class TodoItem extends HTMLElement {
     toggleItem() {
         // The todo-list checks the "completed" attribute to filter based on route
         // (therefore the completed state needs to already be updated before the check)
-        this.setAttribute("completed", this.toggleInput.checked);
+        this.setAttribute("item-completed", this.toggleInput.checked);
 
         this.dispatchEvent(
             new CustomEvent("toggle-item", {
-                detail: { id: this.id, completed: this.toggleInput.checked },
+                detail: { id: this["item-id"], completed: this.toggleInput.checked },
                 bubbles: true,
             })
         );
@@ -100,7 +103,7 @@ class TodoItem extends HTMLElement {
         // (therefore the removal has to happen after the list is updated)
         this.dispatchEvent(
             new CustomEvent("remove-item", {
-                detail: { id: this.id },
+                detail: { id: this["item-id"] },
                 bubbles: true,
             })
         );
@@ -108,14 +111,14 @@ class TodoItem extends HTMLElement {
     }
 
     updateItem(event) {
-        if (event.target.value !== this.title) {
+        if (event.target.value !== this["item-title"]) {
             if (!event.target.value.length) {
                 this.removeItem();
             } else {
-                this.setAttribute("title", event.target.value);
+                this.setAttribute("item-title", event.target.value);
                 this.dispatchEvent(
                     new CustomEvent("update-item", {
-                        detail: { id: this.id, title: event.target.value },
+                        detail: { id: this["item-id"], title: event.target.value },
                         bubbles: true,
                     })
                 );
@@ -153,7 +156,7 @@ class TodoItem extends HTMLElement {
     }
 
     connectedCallback() {
-        this.update("id", "title", "completed");
+        this.update("item-id", "item-title", "item-completed");
 
         this.keysListeners.push(
             useKeyListener({

--- a/resources/todomvc/vanilla-examples/javascript-web-components/src/components/todo-list/todo-list.component.js
+++ b/resources/todomvc/vanilla-examples/javascript-web-components/src/components/todo-list/todo-list.component.js
@@ -33,8 +33,12 @@ class TodoList extends HTMLElement {
     }
 
     addItem(entry) {
+        const { id, title, completed } = entry;
         const element = new TodoItem();
-        Object.keys(entry).forEach((key) => element.setAttribute(key, entry[key]));
+
+        element.setAttribute("item-id", id);
+        element.setAttribute("item-title", title);
+        element.setAttribute("item-completed", completed);
 
         const elementIndex = this.#elements.length;
         this.#elements.push(element);
@@ -48,18 +52,18 @@ class TodoList extends HTMLElement {
 
     removeCompletedItems() {
         this.#elements = this.#elements.filter((element) => {
-            if (element.completed === "true")
+            if (element["item-completed"] === "true")
                 element.removeItem();
 
-            return element.completed === "false";
+            return element["item-completed"] === "false";
         });
     }
 
     toggleItems(completed) {
         this.#elements.forEach((element) => {
-            if (completed && element.completed === "false")
+            if (completed && element["item-completed"] === "false")
                 element.toggleInput.click();
-            else if (!completed && element.completed === "true")
+            else if (!completed && element["item-completed"] === "true")
                 element.toggleInput.click();
         });
     }
@@ -74,10 +78,10 @@ class TodoList extends HTMLElement {
     updateView(element) {
         switch (this.#route) {
             case "completed":
-                element.style.display = element.completed === "true" ? "block" : "none";
+                element.style.display = element["item-completed"] === "true" ? "block" : "none";
                 break;
             case "active":
-                element.style.display = element.completed === "true" ? "none" : "block";
+                element.style.display = element["item-completed"] === "true" ? "none" : "block";
                 break;
             default:
                 element.style.display = "block";
@@ -92,7 +96,7 @@ class TodoList extends HTMLElement {
             case "toggle-item":
             case "add-item":
                 this.#elements.forEach((element) => {
-                    if (element.id === id)
+                    if (element["item-id"] === id)
                         this.updateView(element);
                 });
                 break;

--- a/resources/todomvc/vanilla-examples/javascript-web-components/src/components/todo-list/todo-list.component.js
+++ b/resources/todomvc/vanilla-examples/javascript-web-components/src/components/todo-list/todo-list.component.js
@@ -36,9 +36,9 @@ class TodoList extends HTMLElement {
         const { id, title, completed } = entry;
         const element = new TodoItem();
 
-        element.setAttribute("item-id", id);
-        element.setAttribute("item-title", title);
-        element.setAttribute("item-completed", completed);
+        element.setAttribute("itemid", id);
+        element.setAttribute("itemtitle", title);
+        element.setAttribute("itemcompleted", completed);
 
         const elementIndex = this.#elements.length;
         this.#elements.push(element);
@@ -52,18 +52,18 @@ class TodoList extends HTMLElement {
 
     removeCompletedItems() {
         this.#elements = this.#elements.filter((element) => {
-            if (element["item-completed"] === "true")
+            if (element.itemcompleted === "true")
                 element.removeItem();
 
-            return element["item-completed"] === "false";
+            return element.itemcompleted === "false";
         });
     }
 
     toggleItems(completed) {
         this.#elements.forEach((element) => {
-            if (completed && element["item-completed"] === "false")
+            if (completed && element.itemcompleted === "false")
                 element.toggleInput.click();
-            else if (!completed && element["item-completed"] === "true")
+            else if (!completed && element.itemcompleted === "true")
                 element.toggleInput.click();
         });
     }
@@ -78,10 +78,10 @@ class TodoList extends HTMLElement {
     updateView(element) {
         switch (this.#route) {
             case "completed":
-                element.style.display = element["item-completed"] === "true" ? "block" : "none";
+                element.style.display = element.itemcompleted === "true" ? "block" : "none";
                 break;
             case "active":
-                element.style.display = element["item-completed"] === "true" ? "none" : "block";
+                element.style.display = element.itemcompleted === "true" ? "none" : "block";
                 break;
             default:
                 element.style.display = "block";
@@ -96,13 +96,12 @@ class TodoList extends HTMLElement {
             case "toggle-item":
             case "add-item":
                 this.#elements.forEach((element) => {
-                    if (element["item-id"] === id)
+                    if (element.itemid === id)
                         this.updateView(element);
                 });
                 break;
             case "remove-item":
-                this.#elements = this.#elements.filter((element) => element.id !== id);
-
+                this.#elements = this.#elements.filter((element) => element.itemid !== id);
                 break;
         }
     }


### PR DESCRIPTION
issue https://github.com/WebKit/Speedometer/issues/313

changed this.id => this["item-id"], this.title => this["item-title"] and this.completed => this["item-completed"].
If the brackets are bothersome, I could change it to this.itemid, this.itemtitle, ect... just personal preference to use the above. 

chrome before:
<img width="704" alt="before_chrome" src="https://github.com/WebKit/Speedometer/assets/372973/d9d2f039-5f00-40c9-a1ae-681300c1a673">

chrome after:
<img width="665" alt="after_chrome" src="https://github.com/WebKit/Speedometer/assets/372973/c0adc9f6-cf61-47d5-9a11-27f8c6b9ca39">

firefox before:
<img width="733" alt="before_firefox" src="https://github.com/WebKit/Speedometer/assets/372973/0861c227-9954-463d-aeda-f28b326405e7">

firefox after:
<img width="686" alt="after_firefox" src="https://github.com/WebKit/Speedometer/assets/372973/c420b399-684d-44c5-8c91-9498dcefe78d">

safari before:
<img width="722" alt="before_safari" src="https://github.com/WebKit/Speedometer/assets/372973/7c7f8b28-5f64-4e87-bc79-d8799e3760f5">

safari after:
<img width="715" alt="after_safari" src="https://github.com/WebKit/Speedometer/assets/372973/b4976a59-536d-4f0b-a7b9-41846e1ab3a0">

edge before:
<img width="712" alt="before_edge" src="https://github.com/WebKit/Speedometer/assets/372973/7e49535e-9a09-488d-bdd6-4cf69526c13c">

edge after:
<img width="702" alt="after_edge" src="https://github.com/WebKit/Speedometer/assets/372973/161eafc4-f4ad-4f7e-846d-a5213fdd7e8a">

@kara 
