### PR TITLE
Fix navigation for Firefox

### DIFF
--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -348,10 +348,12 @@ class MainBenchmarkClient {
     }
 
     _setLocationHash(hash) {
-        if (hash === "#home" || hash === "")
+        if (hash === "#home" || hash === "") {
+            window.location.hash = "#home";
             this._removeLocationHash();
-        else
+        } else {
             window.location.hash = hash;
+        }
     }
 
     _removeLocationHash() {


### PR DESCRIPTION
Temporarily set the `#home` hash before clearing it to ensure proper visibility of the home section.