### PR TITLE
TodoMVC jQuery: fix clear completed button

### DIFF
--- a/resources/todomvc/architecture-examples/jquery-complex/dist/app.js
+++ b/resources/todomvc/architecture-examples/jquery-complex/dist/app.js
@@ -57,7 +57,7 @@ jQuery(function ($) {
         bindEvents: function () {
             $('#new-todo').on('keyup', this.create.bind(this));
             $('#toggle-all').on('change', this.toggleAll.bind(this));
-            $('#footer').on('click', '#clear-completed', this.destroyCompleted.bind(this));
+            $('#footer').on('click', '.clear-completed', this.destroyCompleted.bind(this));
             $('#todo-list')
                 .on('change', '.toggle', this.toggle.bind(this))
                 .on('dblclick', 'label', this.edit.bind(this))

--- a/resources/todomvc/architecture-examples/jquery-complex/dist/index.html
+++ b/resources/todomvc/architecture-examples/jquery-complex/dist/index.html
@@ -51,7 +51,7 @@
                     <a {{#eq filter 'completed'}}class="selected"{{/eq}}href="#/completed">Completed</a>
                 </li>
             </ul>
-            {{#if completedTodos}}<button id="clear-completed">Clear completed</button>{{/if}}
+            {{#if completedTodos}}<button class="clear-completed">Clear completed</button>{{/if}}
         </script>
         <!-- <script src="node_modules/todomvc-common/base.js"></script> -->
         <script src="jquery.min.js"></script>

--- a/resources/todomvc/architecture-examples/jquery/dist/app.js
+++ b/resources/todomvc/architecture-examples/jquery/dist/app.js
@@ -57,7 +57,7 @@ jQuery(function ($) {
         bindEvents: function () {
             $('#new-todo').on('keyup', this.create.bind(this));
             $('#toggle-all').on('change', this.toggleAll.bind(this));
-            $('#footer').on('click', '#clear-completed', this.destroyCompleted.bind(this));
+            $('#footer').on('click', '.clear-completed', this.destroyCompleted.bind(this));
             $('#todo-list')
                 .on('change', '.toggle', this.toggle.bind(this))
                 .on('dblclick', 'label', this.edit.bind(this))

--- a/resources/todomvc/architecture-examples/jquery/dist/index.html
+++ b/resources/todomvc/architecture-examples/jquery/dist/index.html
@@ -52,7 +52,7 @@
                     <a {{#eq filter 'completed'}}class="selected"{{/eq}}href="#/completed">Completed</a>
                 </li>
             </ul>
-            {{#if completedTodos}}<button id="clear-completed">Clear completed</button>{{/if}}
+            {{#if completedTodos}}<button class="clear-completed">Clear completed</button>{{/if}}
         </script>
         <!-- <script src="node_modules/todomvc-common/base.js"></script> -->
         <script src="jquery.min.js"></script>

--- a/resources/todomvc/architecture-examples/jquery/index.html
+++ b/resources/todomvc/architecture-examples/jquery/index.html
@@ -52,7 +52,7 @@
                     <a {{#eq filter 'completed'}}class="selected"{{/eq}}href="#/completed">Completed</a>
                 </li>
             </ul>
-            {{#if completedTodos}}<button id="clear-completed">Clear completed</button>{{/if}}
+            {{#if completedTodos}}<button class="clear-completed">Clear completed</button>{{/if}}
         </script>
         <!-- <script src="node_modules/todomvc-common/base.js"></script> -->
         <script src="node_modules/jquery/dist/jquery.min.js"></script>

--- a/resources/todomvc/architecture-examples/jquery/package.json
+++ b/resources/todomvc/architecture-examples/jquery/package.json
@@ -2,6 +2,7 @@
   "name": "todomvc-jquery",
   "private": true,
   "scripts": {
+    "dev": "http-server . -p 7001 -c-1 --cors",
     "build": "node scripts/build.js",
     "serve": "http-server ./dist -p 7002 -c-1 --cors"
   },

--- a/resources/todomvc/architecture-examples/jquery/src/app.js
+++ b/resources/todomvc/architecture-examples/jquery/src/app.js
@@ -57,7 +57,7 @@ jQuery(function ($) {
         bindEvents: function () {
             $('#new-todo').on('keyup', this.create.bind(this));
             $('#toggle-all').on('change', this.toggleAll.bind(this));
-            $('#footer').on('click', '#clear-completed', this.destroyCompleted.bind(this));
+            $('#footer').on('click', '.clear-completed', this.destroyCompleted.bind(this));
             $('#todo-list')
                 .on('change', '.toggle', this.toggle.bind(this))
                 .on('dblclick', 'label', this.edit.bind(this))


### PR DESCRIPTION
Switched 'id' to 'class' for 'clear-completed'.
This is necessary for the css rules to apply correctly.

Fixes issue https://github.com/WebKit/Speedometer/issues/363

@kara 