### PR TITLE
This PR fixes the issue #365: jQuery test only ever marks the first todo item as completed

### DIFF
--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -566,9 +566,8 @@ Suites.push({
             }
         }),
         new BenchmarkTestStep("CompletingAllItems", (page) => {
-            const checkboxes = page.querySelectorAll(".toggle");
             for (let i = 0; i < numberOfItemsToAdd; i++)
-                checkboxes[i].click();
+                page.querySelectorAll(".toggle")[i].click();
         }),
         new BenchmarkTestStep("DeletingAllItems", (page) => {
             for (let i = numberOfItemsToAdd - 1; i >= 0; i--)
@@ -596,9 +595,8 @@ Suites.push({
             }
         }),
         new BenchmarkTestStep("CompletingAllItems", (page) => {
-            const checkboxes = page.querySelectorAll(".toggle");
             for (let i = 0; i < numberOfItemsToAdd; i++)
-                checkboxes[i].click();
+                page.querySelectorAll(".toggle")[i].click();
         }),
         new BenchmarkTestStep("DeletingAllItems", (page) => {
             for (let i = numberOfItemsToAdd - 1; i >= 0; i--)


### PR DESCRIPTION
The bug was caused by jQuery replacing the whole todo list whenever each todo item is toggled.

Fixed it by running querySelectorAll in each iteration.