### PR TITLE
Use getElementsByClassName so that we don't need to use querySelectorAll at every step of the loop

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -96,6 +96,10 @@ class Page {
         return this._wrapElement(element);
     }
 
+    getElementsByClassName(className) {
+        return this._frame.contentDocument.getElementsByClassName(className);
+    }
+
     call(functionName) {
         this._frame.contentWindow[functionName]();
         return null;

--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -566,8 +566,9 @@ Suites.push({
             }
         }),
         new BenchmarkTestStep("CompletingAllItems", (page) => {
+            const allItems = page.getElementsByClassName("toggle");
             for (let i = 0; i < numberOfItemsToAdd; i++)
-                page.querySelectorAll(".toggle")[i].click();
+                allItems[i].click();
         }),
         new BenchmarkTestStep("DeletingAllItems", (page) => {
             for (let i = numberOfItemsToAdd - 1; i >= 0; i--)
@@ -595,8 +596,9 @@ Suites.push({
             }
         }),
         new BenchmarkTestStep("CompletingAllItems", (page) => {
+            const allItems = page.getElementsByClassName("toggle");
             for (let i = 0; i < numberOfItemsToAdd; i++)
-                page.querySelectorAll(".toggle")[i].click();
+                allItems[i].click();
         }),
         new BenchmarkTestStep("DeletingAllItems", (page) => {
             for (let i = numberOfItemsToAdd - 1; i >= 0; i--)

--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -566,9 +566,8 @@ Suites.push({
             }
         }),
         new BenchmarkTestStep("CompletingAllItems", (page) => {
-            const checkboxes = page.querySelectorAll(".toggle");
             for (let i = 0; i < numberOfItemsToAdd; i++)
-                checkboxes[i].click();
+                page.querySelectorAll(".toggle")[i].click();
         }),
         new BenchmarkTestStep("DeletingAllItems", (page) => {
             for (let i = numberOfItemsToAdd - 1; i >= 0; i--)
@@ -596,9 +595,8 @@ Suites.push({
             }
         }),
         new BenchmarkTestStep("CompletingAllItems", (page) => {
-            const checkboxes = page.querySelectorAll(".toggle");
             for (let i = 0; i < numberOfItemsToAdd; i++)
-                checkboxes[i].click();
+                page.querySelectorAll(".toggle")[i].click();
         }),
         new BenchmarkTestStep("DeletingAllItems", (page) => {
             for (let i = numberOfItemsToAdd - 1; i >= 0; i--)


### PR DESCRIPTION
Alternative to #366 