### PR TITLE
Make the github action linter step fail in the case of issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,17 @@ jobs:
             - name: Run linters
               run: |
                   npm run format
+            - name: Check if anything changed
+              run: |
+                  git_status="`LC_ALL=C git status --porcelain --ignore-submodules -unormal 2>&1`"
+                  if [ -n "$git_status" ]; then
+                      printf "Some file(s) changed as the result of formatting, this means that you need to run the formatter on your patch.\n"
+                      printf "Here is what changed:\n"
+                      printf -- "$git_status\n\n"
+                      printf "And here is the diff:\n"
+                      git diff -U8
+                      exit 1
+                  fi
     build:
         name: Build
         runs-on: macos-latest

--- a/about.html
+++ b/about.html
@@ -18,7 +18,10 @@
                     <h1 class="section-header">About Speedometer 3</h1>
                     <div class="section-content">
                         <p>Speedometer 3 is a benchmark for web browsers that measures Web application responsiveness by timing simulated user interactions on various workloads.</p>
-                        <p>It's developed as an open source project, with decisions being made under a <a href="https://github.com/WebKit/Speedometer/blob/main/Governance.md">multistakeholder governance model</a> between the three widely distributed web browser engine projects.
+                        <p>
+                            It's developed as an open source project, with decisions being made under a <a href="https://github.com/WebKit/Speedometer/blob/main/Governance.md">multistakeholder governance model</a> between the three widely distributed
+                            web browser engine projects.
+                        </p>
                         <p>
                             The following high level user journeys are implemented in the current version. Each of these journeys has one or more workloads which test important aspects of it - for example commonly used patterns, frameworks, or
                             technologies.

--- a/resources/todomvc/architecture-examples/angular/angular.json
+++ b/resources/todomvc/architecture-examples/angular/angular.json
@@ -94,6 +94,6 @@
         }
     },
     "cli": {
-      "analytics": false
+        "analytics": false
     }
 }


### PR DESCRIPTION
I noticed that the github action runs the formatter, but doesn't check that anything was actually reformatted as a result. So it was always successful.

To fix the issue, my strategy is to run a special form of `git status` whose output won't change over time. If the output is empty, this means that there's no change. Otherwise the action outputs some helpful diagnostics.

Here are examples of output:
Failing: https://github.com/WebKit/Speedometer/actions/runs/7920439286/job/21623479161?pr=374
Successful: https://github.com/WebKit/Speedometer/actions/runs/7920372392/job/21623262244?pr=374

