### PR TITLE
Enable integration testing in Edge.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
         "format": "npm run pretty:fix ; npm run lint:fix",
         "test:chrome": "BROWSER=chrome node tests/run.mjs",
         "test:firefox": "BROWSER=firefox node tests/run.mjs",
-        "test:safari": "BROWSER=safari node tests/run.mjs"
+        "test:safari": "BROWSER=safari node tests/run.mjs",
+        "test:edge": "BROWSER=edge node tests/run.mjs"
     },
     "devDependencies": {
         "@babel/core": "^7.21.3",

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -57,8 +57,12 @@ switch (BROWSER) {
         capabilities = Capabilities.chrome();
         break;
     }
+    case "edge": {
+        capabilities = Capabilities.edge();
+        break;
+    }
     default: {
-        printHelp(`Invalid browser "${BROWSER}", choices are: "safari", "firefox", "chrome"`);
+        printHelp(`Invalid browser "${BROWSER}", choices are: "safari", "firefox", "chrome", "edge"`);
     }
 }
 


### PR DESCRIPTION
Add edge to the supported browsers for testing. This PR doesn't change the tests run on the github pipelines.