### PR TITLE
Avoid :has selector in CSS.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html data-visible-section="home">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta name="viewport" content="width=850" />

--- a/resources/main.css
+++ b/resources/main.css
@@ -304,9 +304,11 @@ section {
     border-radius: 20px;
 }
 
-section:target,
 section.visible,
-body:not(body:has(section:target)) #home {
+:root[data-visible-section="home"] #home,
+:root[data-visible-section="running"] #running,
+:root[data-visible-section="summary"] #summary,
+:root[data-visible-section="details"] #details {
     display: block;
 }
 
@@ -468,7 +470,7 @@ section#instructions .section-content > * {
     padding-left: calc((var(--viewport-width) - var(--text-width)) / 2);
 }
 
-section#details:target {
+:root[data-visible-section="details"] section#details {
     display: flex;
     flex-direction: column;
 }

--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -355,7 +355,13 @@ class MainBenchmarkClient {
         } else {
             window.location.hash = hash;
         }
+        this._updateVisibleSectionAttribute(hash);
         this._updateDocumentTitle(hash);
+    }
+
+    _updateVisibleSectionAttribute(hash) {
+        const sectionId = hash.substring(1);
+        document.documentElement.setAttribute("data-visible-section", sectionId);
     }
 
     _updateDocumentTitle(hash) {


### PR DESCRIPTION
Fixes #394.

This changes how section visibility is controlled. All sections are still `display:none` by default.
Rather than becoming `display:block` when they match `:target`, they now become `display:block` if their ID matches the value of the root element's `data-visible-section` attribute - we hardcode the four section names "home", "running", "summary" and "details".

This lets us default to the home section just by setting `<html data-visible-section="home">` in index.html, and we can avoid the `:has` selector.

Now Speedometer can run in older browsers which don't support `:has`.