### PR TITLE
Fix Cross-platform issue with npm script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,6 @@ jobs:
         strategy:
             matrix:
                 browser: [chrome, firefox, safari]
-        env:
-            BROWSER: ${{ matrix.browser }}
         steps:
             - name: Checkout Branch
               uses: actions/checkout@v3
@@ -58,4 +56,4 @@ jobs:
             - name: Run tests
               run: |
                   echo "Running in $BROWSER"
-                  node tests/run.mjs
+                  npm run test:${{ matrix.browser }}

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
         "pretty:check": "prettier --check ./",
         "pretty:fix": "prettier --write ./",
         "format": "npm run pretty:fix ; npm run lint:fix",
-        "test:chrome": "BROWSER=chrome node tests/run.mjs",
-        "test:firefox": "BROWSER=firefox node tests/run.mjs",
-        "test:safari": "BROWSER=safari node tests/run.mjs",
-        "test:edge": "BROWSER=edge node tests/run.mjs"
+        "test:chrome": "node tests/run.mjs --browser chrome",
+        "test:firefox": "node tests/run.mjs --browser firefox",
+        "test:safari": "node tests/run.mjs --browser safari",
+        "test:edge": "node tests/run.mjs --browser edge"
     },
     "devDependencies": {
         "@babel/core": "^7.21.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "lint:fix": "eslint \"**/*.{js,mjs,jsx,ts,tsx}\" --fix",
         "pretty:check": "prettier --check ./",
         "pretty:fix": "prettier --write ./",
-        "format": "npm run pretty:fix ; npm run lint:fix",
+        "format": "npm run pretty:fix && npm run lint:fix",
         "test:chrome": "node tests/run.mjs --browser chrome",
         "test:firefox": "node tests/run.mjs --browser firefox",
         "test:safari": "node tests/run.mjs --browser safari",

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -39,7 +39,7 @@ const options = commandLineArgs(optionDefinitions);
 if ("help" in options)
     printHelp();
 
-const BROWSER = options?.browser || process.env.BROWSER;
+const BROWSER = options?.browser;
 if (!BROWSER)
     printHelp("No browser specified, use $BROWSER or --browser");
 


### PR DESCRIPTION
# closes #396 
This change allows the npm test scripts to also run on windows machines.

The PR:
- switches the way the browser is defined when running tests. Initially, the browser was determined via environment variables `(e.g., BROWSER=chrome node tests/run.mjs)`. However, this PR alters the approach to use command line arguments instead `(e.g., node tests/run.mjs --browser chrome)`.
- The Run tests step in the ci workflow now uses the npm scripts
- make `npm run format` work as well.

