### PR TITLE
Deconfuse Geomean Metric and geomean aggregate value

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,13 +78,13 @@
                     <h1 class="section-header">Detailed Results</h1>
                     <div class="section-content all-metric-results">
                         <div class="aggregated-metric-result">
-                            <h2>Geomean</h2>
+                            <h2>Aggregate Metric</h2>
                             <div id="geomean-chart"></div>
-                            <h2>Tests</h2>
+                            <h2>Test Metrics Overview</h2>
                             <div id="tests-chart"></div>
                         </div>
                         <br />
-                        <h2>Detailed Metrics</h2>
+                        <h2>Test Metrics Details</h2>
                         <div id="metrics-results"></div>
                     </div>
                     <div class="buttons section-footer">

--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -574,9 +574,9 @@ export class BenchmarkRunner {
             // Prepare all iteration metrics so they are listed at the end of
             // of the _metrics object, before "Total" and "Score".
             for (let i = 0; i < this._iterationCount; i++)
-                iterationTotalMetric(i);
-            getMetric("Geomean");
-            getMetric("Score", "score");
+                iterationTotalMetric(i).description = `Test totals for iteration ${i}`;
+            getMetric("Geomean", "ms").description = "Geomean of test totals"
+            getMetric("Score", "score").description = "Scaled inverse of the Geomean";
         }
 
         const geomean = getMetric("Geomean");

--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -575,7 +575,7 @@ export class BenchmarkRunner {
             // of the _metrics object, before "Total" and "Score".
             for (let i = 0; i < this._iterationCount; i++)
                 iterationTotalMetric(i).description = `Test totals for iteration ${i}`;
-            getMetric("Geomean", "ms").description = "Geomean of test totals"
+            getMetric("Geomean", "ms").description = "Geomean of test totals";
             getMetric("Score", "score").description = "Scaled inverse of the Geomean";
         }
 

--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -235,6 +235,10 @@ class MainBenchmarkClient {
         csvLink.setAttribute("download", `${filePrefix}.csv`);
     }
 
+    _renderOverviewChart(id, metric) {
+
+    }
+
     prepareUI() {
         window.addEventListener("hashchange", this._hashChangeHandler.bind(this));
         window.addEventListener("resize", this._resizeScreeHandler.bind(this));

--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -235,10 +235,6 @@ class MainBenchmarkClient {
         csvLink.setAttribute("download", `${filePrefix}.csv`);
     }
 
-    _renderOverviewChart(id, metric) {
-
-    }
-
     prepareUI() {
         window.addEventListener("hashchange", this._hashChangeHandler.bind(this));
         window.addEventListener("resize", this._resizeScreeHandler.bind(this));

--- a/resources/metric.mjs
+++ b/resources/metric.mjs
@@ -13,7 +13,8 @@ export class Metric {
         this.description = "";
 
         this.mean = 0.0;
-        // Make "geomean" non-enumerable so we don't serialize it with JSON.stringify.
+        // Make "geomean" non-enumerable so we don't serialize it with JSON.stringify
+        // and avoid some confusion with the top-level Geomean metric.
         Object.defineProperty(this, "geomean", {
             writable: true,
             value: 0,

--- a/resources/metric.mjs
+++ b/resources/metric.mjs
@@ -13,6 +13,7 @@ export class Metric {
         this.description = "";
 
         this.mean = 0.0;
+        // Make "geomean" non-enumerable so we don't serialize it with JSON.stringify.
         Object.defineProperty(this, "geomean", {
             writable: true,
             value: 0,

--- a/resources/metric.mjs
+++ b/resources/metric.mjs
@@ -10,9 +10,13 @@ export class Metric {
             throw new Error(`Invalid metric.name=${name}, expected string.`);
         this.name = name;
         this.unit = unit;
+        this.description = "";
 
         this.mean = 0.0;
-        this.geomean = 0.0;
+        Object.defineProperty(this, "geomean", {
+            writable: true,
+            value: 0,
+        });
         this.delta = 0.0;
         this.percentDelta = 0.0;
 
@@ -21,7 +25,6 @@ export class Metric {
         this.max = 0.0;
 
         this.values = [];
-        this.children = [];
 
         // Mark properties which refer to other Metric objects as
         // non-enumerable to avoid issue with JSON.stringify due to circular
@@ -30,6 +33,10 @@ export class Metric {
             parent: {
                 writable: true,
                 value: undefined,
+            },
+            children: {
+                writable: true,
+                value: [],
             },
         });
     }


### PR DESCRIPTION
The metric's "geomean" aggregate value can be easily confused with the top-level Geomean metric (issue #407).

- Don't serialize "geomean" in the JSON data
- Add descriptions to Score, Geomean, and Iteration metrics that are serialized in the JSON data
- Make the detail view titles more descriptive