### PR TITLE
Remove obsolete eslint ignore

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -453,7 +453,6 @@ export class BenchmarkRunner {
     }
 
     async _runTestAndRecordResults(suite, test) {
-        /* eslint-disable-next-line no-async-promise-executor */
         if (this._client?.willRunTest)
             await this._client.willRunTest(suite, test);
 


### PR DESCRIPTION
The offending `new Promise(async ...)` code was already removed in 19184dc69432fa7e511e13f3318c8c3e1acd28ca but this linting comment remained.