### PR TITLE
Manually install Firefox on macos-latest image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
             matrix:
                 browser: [chrome, firefox, safari]
         steps:
-            - if: ${{ matrix.browser == "firefox" }}
+            - if: ${{ matrix.browser }} == 'firefox'
               - name: Setup firefox
                 run: brew install --cask firefox
             - name: Checkout Branch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
             - name: Install
               run: npm install
             - name: Run linters
-              run:  npm run format
+              run: npm run format
             - name: Check if anything changed
               run: |
                   git_status="`LC_ALL=C git status --porcelain --ignore-submodules -unormal 2>&1`"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
                 browser: [chrome, firefox, safari]
         steps:
             - name: Setup firefox
-              if: ${{ matrix.browser }} == 'firefox'
+              if: ${{ matrix.browser == 'firefox' }}
               run: brew install --cask firefox
             - name: Checkout Branch
               uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
             matrix:
                 browser: [chrome, firefox, safari]
         steps:
-            - name: Setup firefox
+            - name: Install Firefox
               if: ${{ matrix.browser == 'firefox' }}
               run: brew install --cask firefox
             - name: Checkout Branch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,9 @@ jobs:
               with:
                   node-version: 18.13.0
             - name: Install
-              run: |
-                  npm install
+              run: npm install
             - name: Run linters
-              run: |
-                  npm run format
+              run:  npm run format
             - name: Check if anything changed
               run: |
                   git_status="`LC_ALL=C git status --porcelain --ignore-submodules -unormal 2>&1`"
@@ -46,13 +44,14 @@ jobs:
         steps:
             - name: Checkout Branch
               uses: actions/checkout@v3
+            - name: Setup firefox
+              run: brew install --cask firefox
             - name: Setup Node
               uses: actions/setup-node@v3
               with:
                   node-version: 18.13.0
             - name: Install
-              run: |
-                  npm install
+              run: npm install
             - name: Run tests
               run: |
                   echo "Running in $BROWSER"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,9 @@ jobs:
             matrix:
                 browser: [chrome, firefox, safari]
         steps:
-            - if: ${{ matrix.browser }} == 'firefox'
-              - name: Setup firefox
-                run: brew install --cask firefox
+            - name: Setup firefox
+              if: ${{ matrix.browser }} == 'firefox'
+              run: brew install --cask firefox
             - name: Checkout Branch
               uses: actions/checkout@v3
             - name: Setup Node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,10 +42,11 @@ jobs:
             matrix:
                 browser: [chrome, firefox, safari]
         steps:
+            - if: ${{ matrix.browser == "firefox" }}
+              - name: Setup firefox
+                run: brew install --cask firefox
             - name: Checkout Branch
               uses: actions/checkout@v3
-            - name: Setup firefox
-              run: brew install --cask firefox
             - name: Setup Node
               uses: actions/setup-node@v3
               with:


### PR DESCRIPTION
Looks like macos-latest does not include Firefox. 
Manually running `brew install --cask firefox` on the firefox test job solves the problem.