### PR TITLE
Change default port to 8900 

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -25,9 +25,9 @@ In your working directory, open terminal and paste the following commands:
 
 1. In your terminal run:
     ```sh
-        npm run dev
+        PORT=8900 npm run dev # Passing the env var PORT is optional
     ```
-2. Open your browser of choice and navigate to [http://127.0.0.1:7000](http://127.0.0.1:7000)
+2. Open your browser of choice and navigate to [http://127.0.0.1:8900](http://127.0.0.1:8900)
 
 ## Local Server
 

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     },
     "license": "SEE LICENSE IN LICENSE",
     "scripts": {
-        "dev": "http-server ./ -p 7000 -c-1 --cors",
-        "server": "http-server ./ -p 7000 --cors",
+        "dev": "http-server ./ -c-1 --cors",
+        "server": "http-server ./ --cors",
         "lint:check": "eslint **/*.{js,mjs,jsx,ts,tsx}",
         "lint:fix": "eslint \"**/*.{js,mjs,jsx,ts,tsx}\" --fix",
         "pretty:check": "prettier --check ./",

--- a/resources/charts/README.md
+++ b/resources/charts/README.md
@@ -41,7 +41,7 @@ convenient to open these benchmarks with their specific files.
 
 You can load this benchmark with the `/observable-plot.html` page, for example
 http://localhost:5173/observable-plot.html if you run it locally or
-http://localhost:7000/resources/charts/dist/observable-plot.html in the
+http://localhost:8900/resources/charts/dist/observable-plot.html in the
 context of the speedometer.
 
 Observable Plot is D3-based and outputs SVG.
@@ -63,7 +63,7 @@ US. You can consult them in the [datasets directory](./datasets).
 
 You can load this benchmark with the `/chartjs.html` page, for example
 http://localhost:5173/chartjs.html if you run it locally or
-http://localhost:7000/resources/charts/dist/chartjs.html in the
+http://localhost:8900/resources/charts/dist/chartjs.html in the
 context of speedometer.
 
 ChartJS is canvas-based.

--- a/resources/editors/README.md
+++ b/resources/editors/README.md
@@ -24,4 +24,4 @@ The test simulates a real-world user flow by loading a number of popular editor 
 
 The app was created with `npm create vite@latest editors`, and can be previewed with `npm run dev`. In order to update the files run in the harness you have to use `npm run build` which will recreate the `dist/` directory.
 
-The built test can be loaded within the harness using i.e. http://localhost:7000/?suite=Editor-CodeMirror&startAutomatically=true, or the static versions at http://localhost:7000/resources/editors/dist/.
+The built test can be loaded within the harness using i.e. http://localhost:8900/?suite=Editor-CodeMirror&startAutomatically=true, or the static versions at http://localhost:7000/resources/editors/dist/.


### PR DESCRIPTION
Port 7000 is occupied by default on macOS.
This also makes it simpler how to customize it
(use env var instead of hardcoded in the package.json)

https://github.com/WebKit/Speedometer/issues/325