### PR TITLE
Split off SuiteRunner class

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -456,17 +456,8 @@ export class BenchmarkRunner {
     async runSuite(suite) {
         // FIXME: Encapsulate more state in the SuiteRunner.
         // FIXME: Return and use measured values from SuiteRunner.
-        const suiteRunner = new SuiteRunner(this, this._measuredValues, this._frame, this._page, this._client, suite);
+        const suiteRunner = new SuiteRunner(this._measuredValues, this._frame, this._page, this._client, suite);
         await suiteRunner.run();
-    }
-
-    async loadFrame(suite) {
-        return new Promise((resolve, reject) => {
-            const frame = this._page._frame;
-            frame.onload = () => resolve();
-            frame.onerror = () => reject();
-            frame.src = suite.url;
-        });
     }
 
     async _finalize() {
@@ -543,8 +534,7 @@ export class BenchmarkRunner {
 // FIXME: Create AsyncSuiteRunner subclass.
 // FIXME: Create RemoteSuiteRunner subclass.
 class SuiteRunner {
-    constructor(runner, measuredValues, frame, page, client, suite) {
-        this._runner = runner;
+    constructor(measuredValues, frame, page, client, suite) {
         // FIXME: Create SuiteRunner-local measuredValues.
         this._measuredValues = measuredValues;
         this._frame = frame;
@@ -596,8 +586,12 @@ class SuiteRunner {
     }
 
     async _loadFrame(suite) {
-        // FIXME: use BenchmarkRunner method directly.
-        await this._runner.loadFrame(suite);
+        return new Promise((resolve, reject) => {
+            const frame = this._page._frame;
+            frame.onload = () => resolve();
+            frame.onerror = () => reject();
+            frame.src = suite.url;
+        });
     }
 
     async _runTestAndRecordResults(suite, test) {

--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -456,7 +456,8 @@ export class BenchmarkRunner {
     async runSuite(suite) {
         // FIXME: Encapsulate more state in the SuiteRunner.
         // FIXME: Return and use measured values from SuiteRunner.
-        await new SuiteRunner(this, this._measuredValues, this._frame, this._page, this._client, suite).run();
+        const suiteRunner = new SuiteRunner(this, this._measuredValues, this._frame, this._page, this._client, suite);
+        await suiteRunner.run();
     }
 
     async loadFrame(suite) {
@@ -595,7 +596,8 @@ class SuiteRunner {
     }
 
     async _loadFrame(suite) {
-        this._runner.loadFrame(suite);
+        // FIXME: use BenchmarkRunner method directly.
+        await this._runner.loadFrame(suite);
     }
 
     async _runTestAndRecordResults(suite, test) {

--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -437,7 +437,7 @@ export class BenchmarkRunner {
             }
 
         } finally {
-            // await this._finishRunAllSuites();
+            await this._finishRunAllSuites();
         }
     }
 

--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -533,7 +533,7 @@ export class BenchmarkRunner {
 
 // FIXME: Create AsyncSuiteRunner subclass.
 // FIXME: Create RemoteSuiteRunner subclass.
-class SuiteRunner {
+export class SuiteRunner {
     constructor(measuredValues, frame, page, client, suite) {
         // FIXME: Create SuiteRunner-local measuredValues.
         this._measuredValues = measuredValues;


### PR DESCRIPTION
Move Suite-related code to a separate SuiteRunner class.
This happens in preparation for async and remote suites where it will be cleaner to handle the code paths independently instead of adding more functionality to the BenchmarkRunner class.