### PR TITLE
Cleanup to prepare for postMessage / remote runner

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -403,10 +403,6 @@ export class BenchmarkRunner {
         const prepareEndLabel = "runner-prepare-end";
 
         performance.mark(prepareStartLabel);
-        this._removeFrame();
-        await this._appendFrame();
-        this._page = new Page(this._frame);
-
         let suites = [...this._suites];
         if (this._suiteOrderRandomNumberGenerator)
             this._shuffleSuites(suites);
@@ -432,8 +428,13 @@ export class BenchmarkRunner {
         const suites = await this._prepareAllSuites();
         try {
             for (const suite of suites) {
-                if (!suite.disabled)
-                    await this.runSuite(suite);
+                if (!suite.disabled) {
+                    await this._appendFrame();
+                    this._page = new Page(this._frame);
+                    // eslint-disable-next-line no-unused-expressions
+                    suite.config ? await this.runRemoteSuite(suite) : await this.runSuite(suite);
+                    this._removeFrame();
+                }
             }
 
         } finally {

--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -431,8 +431,7 @@ export class BenchmarkRunner {
                 if (!suite.disabled) {
                     await this._appendFrame();
                     this._page = new Page(this._frame);
-                    // eslint-disable-next-line no-unused-expressions
-                    suite.config ? await this.runRemoteSuite(suite) : await this.runSuite(suite);
+                    await this.runSuite(suite);
                     this._removeFrame();
                 }
             }


### PR DESCRIPTION
currently, we append / remove the iframe element in the `_prepareAllSuites` phase, and just load a new source for each suite, by assigning the new source url. 

A cleaner approach, which I introduce here, adds and removes the iframe element between each suite. 
This is also a safer approach for the postMessage api that will follow in a separate pr. 

No noticeable impact observed with crossbench.

Current main branch: 
`browser                                     Safari                    Firefox                Google Chrome
TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  39.16 ± 0.80%             44.42 ± 0.69%          46.60 ± 0.94%
TodoMVC-React-Redux                         29.96 ± 1.1%              35.24 ± 0.29%          32.02 ± 2.1%
TodoMVC-JavaScript-ES5                      28.86 ± 0.47%             36.74 ± 0.98%          38.72 ± 1.7%
NewsSite-Next                               57.96 ± 1.0%              75.2 ± 1.8%            77.8 ± 2.8%
TodoMVC-WebComponents                       12.90 ± 2.0%              19.04 ± 1.5%           14.90 ± 0.94%
NewsSite-Nuxt                               62.98 ± 1.2%              67.0 ± 1.6%            63.8 ± 1.7%
TodoMVC-Lit-Complex-DOM                     14.12 ± 1.1%              21.22 ± 1.5%           18.33 ± 3.3%
Charts-observable-plot                      37.74 ± 1.1%              44.98 ± 0.55%          41.74 ± 1.8%
TodoMVC-Preact-Complex-DOM                  12.92 ± 3.6%              14.22 ± 1.6%           12.7 ± 9.7%
TodoMVC-Angular-Complex-DOM                 31.98 ± 0.72%             36.78 ± 0.83%          28.45 ± 1.9%
TodoMVC-Svelte-Complex-DOM                  11.26 ± 2.1%              14.08 ± 2.9%           11.15 ± 2.2%
Editor-CodeMirror                           22.64 ± 0.82%             21.28 ± 0.69%          21.63 ± 2.9%
TodoMVC-Backbone                            23.40 ± 0.90%             26.56 ± 1.7%           22.32 ± 3.2%
TodoMVC-jQuery                              85.2 ± 1.4%               112.1 ± 1.4%           98.1 ± 1.6%
TodoMVC-React-Complex-DOM                   31.44 ± 1.2%              35.00 ± 0.85%          32.30 ± 1.3%
Charts-chartjs                              34.92 ± 1.6%              37.68 ± 0.74%          72.70 ± 0.59%
Editor-TipTap                               57.54 ± 0.55%             79.22 ± 0.38%          69.72 ± 0.63%
Perf-Dashboard                              32.82 ± 1.1%              35.04 ± 0.69%          33.03 ± 1.4%
React-Stockcharts-SVG                       70.24 ± 1.2%              77.90 ± 0.99%          72.84 ± 0.52%
TodoMVC-Vue                                 19.94 ± 1.0%              23.68 ± 1.7%           19.01 ± 1.5%
Score                                       32.878 ± 0.17%            27.55 ± 0.51%          29.45 ± 0.35%`

this pr:
`browser                                     Safari                    Firefox                Google Chrome
TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  39.78 ± 1.3%              45.06 ± 0.98%          46.28 ± 1.2%
TodoMVC-React-Redux                         30.10 ± 1.2%              35.14 ± 0.93%          32.19 ± 2.0%
TodoMVC-JavaScript-ES5                      29.36 ± 1.4%              37.08 ± 2.1%           38.12 ± 0.94%
NewsSite-Next                               57.70 ± 0.31%             75.36 ± 1.1%           77.1 ± 1.9%
TodoMVC-WebComponents                       13.24 ± 1.8%              19.04 ± 3.6%           14.880 ± 0.35%
NewsSite-Nuxt                               62.98 ± 1.3%              66.8 ± 1.5%            64.34 ± 1.0%
TodoMVC-Lit-Complex-DOM                     14.54 ± 2.0%              21.04 ± 1.6%           18.35 ± 3.3%
Charts-observable-plot                      39.72 ± 1.2%              45.30 ± 0.83%          41.55 ± 1.5%
TodoMVC-Preact-Complex-DOM                  13.10 ± 2.3%              14.18 ± 3.4%           11.76 ± 2.1%
TodoMVC-Angular-Complex-DOM                 32.14 ± 1.5%              37.06 ± 1.9%           28.17 ± 0.69%
TodoMVC-Svelte-Complex-DOM                  11.50 ± 1.5%              14.18 ± 4.7%           11.25 ± 6.3%
Editor-CodeMirror                           22.86 ± 2.5%              21.40 ± 1.7%           21.72 ± 0.83%
TodoMVC-Backbone                            23.54 ± 1.1%              26.72 ± 1.4%           22.04 ± 2.4%
TodoMVC-jQuery                              83.9 ± 2.3%               111.4 ± 2.1%           97.3 ± 1.5%
TodoMVC-React-Complex-DOM                   31.54 ± 2.8%              34.98 ± 2.0%           32.17 ± 2.1%
Charts-chartjs                              36.04 ± 1.9%              37.86 ± 0.40%          73.15 ± 1.00%
Editor-TipTap                               57.30 ± 0.72%             78.94 ± 0.94%          70.30 ± 0.47%
Perf-Dashboard                              33.54 ± 1.0%              35.28 ± 0.68%          33.49 ± 2.4%
React-Stockcharts-SVG                       69.74 ± 0.75%             77.50 ± 0.84%          72.77 ± 0.79%
TodoMVC-Vue                                 20.30 ± 1.8%              24.02 ± 2.2%           18.97 ± 1.3%
Score                                       32.51 ± 0.62%             27.50 ± 0.73%          29.57 ± 0.36%`