### PR TITLE
Add more flexible TEST_INVOKER_LOOKUP

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -315,6 +315,12 @@ class RAFTestInvoker extends TestInvoker {
     }
 }
 
+const TEST_INVOKER_LOOKUP = {
+    __proto__: null,
+    timer: TimerTestInvoker,
+    raf: RAFTestInvoker,
+};
+
 // https://stackoverflow.com/a/47593316
 function seededHashRandomNumberGenerator(a) {
     return function () {
@@ -642,7 +648,7 @@ export class SuiteRunner {
             performance.measure(`${suite.name}.${test.name}-async`, asyncStartLabel, asyncEndLabel);
         };
         const report = () => this._recordTestResults(suite, test, syncTime, asyncTime);
-        const invokerClass = params.measurementMethod === "raf" ? RAFTestInvoker : TimerTestInvoker;
+        const invokerClass = TEST_INVOKER_LOOKUP[params.measurementMethod];
         const invoker = new invokerClass(runSync, measureAsync, report);
 
         return invoker.start();


### PR DESCRIPTION
Use a lookup dict for more future-proof way to look up a test invoker class.