### PR TITLE
Add local results variable to SuiteRunner

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -567,7 +567,7 @@ export class SuiteRunner {
 
         performance.mark(suitePrepareStartLabel);
         await this._loadFrame();
-        await suite.prepare(this._page);
+        await this._suite.prepare(this._page);
         performance.mark(suitePrepareEndLabel);
 
         performance.measure(`suite-${suiteName}-prepare`, suitePrepareStartLabel, suitePrepareEndLabel);
@@ -605,9 +605,9 @@ export class SuiteRunner {
         });
     }
 
-    async _runTestAndRecordResults(suite, test) {
+    async _runTestAndRecordResults(test) {
         if (this._client?.willRunTest)
-            await this._client.willRunTest(suite, test);
+            await this._client.willRunTest(this._suite, test);
 
         // Prepare all mark labels outside the measuring loop.
         const suiteName = this._suite.name;
@@ -655,6 +655,7 @@ export class SuiteRunner {
             performance.measure(`${suiteName}.${testName}-sync`, startLabel, syncEndLabel);
             performance.measure(`${suiteName}.${testName}-async`, asyncStartLabel, asyncEndLabel);
         };
+
         const report = () => this._recordTestResults(suite, test, syncTime, asyncTime);
         const invokerClass = TEST_INVOKER_LOOKUP[params.measurementMethod];
         const invoker = new invokerClass(runSync, measureAsync, report);

--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -656,7 +656,7 @@ export class SuiteRunner {
             performance.measure(`${suiteName}.${testName}-async`, asyncStartLabel, asyncEndLabel);
         };
 
-        const report = () => this._recordTestResults(suite, test, syncTime, asyncTime);
+        const report = () => this._recordTestResults(test, syncTime, asyncTime);
         const invokerClass = TEST_INVOKER_LOOKUP[params.measurementMethod];
         const invoker = new invokerClass(runSync, measureAsync, report);
 

--- a/tests/benchmark-runner-tests.mjs
+++ b/tests/benchmark-runner-tests.mjs
@@ -192,7 +192,7 @@ describe("BenchmarkRunner", () => {
                 await runner._appendFrame();
                 performanceMarkSpy = spy(window.performance, "mark");
                 const suiteRunner = new SuiteRunner(runner._measuredValues, runner._frame, runner._page, runner._client, suite);
-                await suiteRunner._runTestAndRecordResults(suite.tests[0]);
+                await suiteRunner._runTestAndRecordResults(suite, suite.tests[0]);
             });
 
             it("should run client pre and post hooks if present", () => {
@@ -227,7 +227,7 @@ describe("BenchmarkRunner", () => {
 
                     // instantiate recorded test results
                     const suiteRunner = new SuiteRunner(runner._measuredValues, runner._frame, runner._page, runner._client, suite);
-                    await suiteRunner._runTestAndRecordResults(suite.tests[0]);
+                    await suiteRunner._runTestAndRecordResults(suite, suite.tests[0]);
 
                     await runner._finalize();
                 });

--- a/tests/benchmark-runner-tests.mjs
+++ b/tests/benchmark-runner-tests.mjs
@@ -192,7 +192,7 @@ describe("BenchmarkRunner", () => {
                 await runner._appendFrame();
                 performanceMarkSpy = spy(window.performance, "mark");
                 const suiteRunner = new SuiteRunner(runner._measuredValues, runner._frame, runner._page, runner._client, suite);
-                await suiteRunner._runTestAndRecordResults(suite, suite.tests[0]);
+                await suiteRunner._runTestAndRecordResults(suite.tests[0]);
             });
 
             it("should run client pre and post hooks if present", () => {
@@ -227,7 +227,7 @@ describe("BenchmarkRunner", () => {
 
                     // instantiate recorded test results
                     const suiteRunner = new SuiteRunner(runner._measuredValues, runner._frame, runner._page, runner._client, suite);
-                    await suiteRunner._runTestAndRecordResults(suite, suite.tests[0]);
+                    await suiteRunner._runTestAndRecordResults(suite.tests[0]);
 
                     await runner._finalize();
                 });


### PR DESCRIPTION
We can migrate some of the measuredValue logic directly to the SuiteRunner and simplify the code a bit.
Additionally this will allow us to generate more flexible metrics in the future.