### PR TITLE
Test Runner cleanup - for our internal tests

### DIFF
--- a/tests/benchmark-runner-tests.mjs
+++ b/tests/benchmark-runner-tests.mjs
@@ -164,7 +164,7 @@ describe("BenchmarkRunner", () => {
             });
 
             it("should prepare the suite first", async () => {
-                assert.calledOnce(_prepareSuiteSpy);
+                assert.calledTwice(_prepareSuiteSpy);
                 assert.calledOnce(_suitePrepareSpy);
                 assert.calledOnce(_loadFrameStub);
             });

--- a/tests/benchmark-runner-tests.mjs
+++ b/tests/benchmark-runner-tests.mjs
@@ -164,7 +164,7 @@ describe("BenchmarkRunner", () => {
             });
 
             it("should prepare the suite first", async () => {
-                assert.calledTwice(_prepareSuiteSpy);
+                assert.calledOnce(_prepareSuiteSpy);
                 assert.calledOnce(_suitePrepareSpy);
                 assert.calledOnce(_loadFrameStub);
             });

--- a/tests/index.html
+++ b/tests/index.html
@@ -30,12 +30,45 @@
         <script src="../resources/benchmark-runner.mjs" type="module"></script>
         <script src="benchmark-runner-tests.mjs" type="module"></script>
         <script type="module">
-            const runner = mocha.run();
+            function startTest() {
+            const runner = mocha.run()
+            window.mochaResults = runner;
+
+            function createReport(node) {
+                const tree = {
+                    tests: [],
+                    suites: [],
+                    id: node.id,
+                    title: node.title,
+                    root: node.root,
+                };
+
+                for (const test of node.tests) {
+                    tree.tests.push({
+                        id: test.id,
+                        title: test.title,
+                        state: test.state,
+                        error: {
+                            name: test?.err?.name,
+                            message: test?.err?.message
+                        }
+                    });
+                }
+
+                for (const suite of node.suites) {
+                    tree.suites.push(createReport(suite));
+                }
+
+                return tree;
+            }
+
             runner.on("end", function () {
-                const event = new Event("complete");
+                window.suite = createReport(runner.suite);
+                const event = new Event("test-complete");
                 window.dispatchEvent(event);
             });
-            window.mochaResults = runner;
+            }
+            window.addEventListener("start-test", startTest);
         </script>
     </body>
 </html>

--- a/tests/index.html
+++ b/tests/index.html
@@ -31,42 +31,42 @@
         <script src="benchmark-runner-tests.mjs" type="module"></script>
         <script type="module">
             function startTest() {
-            const runner = mocha.run()
-            window.mochaResults = runner;
+                const runner = mocha.run();
+                window.mochaResults = runner;
 
-            function createReport(node) {
-                const tree = {
-                    tests: [],
-                    suites: [],
-                    id: node.id,
-                    title: node.title,
-                    root: node.root,
-                };
+                function createReport(node) {
+                    const tree = {
+                        tests: [],
+                        suites: [],
+                        id: node.id,
+                        title: node.title,
+                        root: node.root,
+                    };
 
-                for (const test of node.tests) {
-                    tree.tests.push({
-                        id: test.id,
-                        title: test.title,
-                        state: test.state,
-                        error: {
-                            name: test?.err?.name,
-                            message: test?.err?.message
-                        }
-                    });
+                    for (const test of node.tests) {
+                        tree.tests.push({
+                            id: test.id,
+                            title: test.title,
+                            state: test.state,
+                            error: {
+                                name: test?.err?.name,
+                                message: test?.err?.message,
+                            },
+                        });
+                    }
+
+                    for (const suite of node.suites) {
+                        tree.suites.push(createReport(suite));
+                    }
+
+                    return tree;
                 }
 
-                for (const suite of node.suites) {
-                    tree.suites.push(createReport(suite));
-                }
-
-                return tree;
-            }
-
-            runner.on("end", function () {
-                window.suite = createReport(runner.suite);
-                const event = new Event("test-complete");
-                window.dispatchEvent(event);
-            });
+                runner.on("end", function () {
+                    window.suite = createReport(runner.suite);
+                    const event = new Event("test-complete");
+                    window.dispatchEvent(event);
+                });
             }
             window.addEventListener("start-test", startTest);
         </script>

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -4,6 +4,7 @@ import serve from "./server.mjs";
 import { Builder, Capabilities } from "selenium-webdriver";
 import commandLineArgs from "command-line-args";
 import commandLineUsage from "command-line-usage";
+import assert from "assert";
 
 const optionDefinitions = [
     { name: "browser", type: String, description: "Set the browser to test, choices are [safari, firefox, chrome]. By default the $BROWSER env variable is used." },
@@ -34,12 +35,10 @@ function printHelp(message = "") {
 
 const options = commandLineArgs(optionDefinitions);
 
-if ("help" in options)
-    printHelp();
+if ("help" in options) printHelp();
 
 const BROWSER = options?.browser;
-if (!BROWSER)
-    printHelp("No browser specified, use $BROWSER or --browser");
+if (!BROWSER) printHelp("No browser specified, use $BROWSER or --browser");
 
 let capabilities;
 switch (BROWSER) {
@@ -112,12 +111,13 @@ async function test() {
         });
 
         printTree(result.suite);
-        if (result.stats.failures > 0) {
-            console.error("\n\x1b[31m✖ Not all tests passed!\n");
-            process.exit(1);
-        }
+
+        console.log("\nChecking for passed tests...");
+        assert(result.stats.passes > 0);
+        console.log("Checking for failed tests...");
+        assert(result.stats.failures === 0);
     } finally {
-        console.log("\n\x1b[32m✓ All tests passed!\n");
+        console.log("\nTests complete!");
         driver.quit();
         server.close();
     }

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -112,7 +112,6 @@ async function test() {
             window.dispatchEvent(event);
         });
 
-        // console.log("stats", result.stats);
         printTree(result.suite);
         if (result.stats.failures > 0){
             console.error("\n\x1b[31m✖ Not all tests passed!\n");

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -4,7 +4,6 @@ import serve from "./server.mjs";
 import { Builder, Capabilities } from "selenium-webdriver";
 import commandLineArgs from "command-line-args";
 import commandLineUsage from "command-line-usage";
-import assert from "assert";
 
 const optionDefinitions = [
     { name: "browser", type: String, description: "Set the browser to test, choices are [safari, firefox, chrome]. By default the $BROWSER env variable is used." },
@@ -76,9 +75,9 @@ function printTree(node) {
     for (const test of node.tests) {
         console.group();
         if (test.state === "passed") {
-            console.log("\x1b[32m✓", `\x1b[30m${ test.title}`);
+            console.log("\x1b[32m✓", `\x1b[30m${test.title}`);
         } else {
-            console.log("\x1b[31m✖", `\x1b[30m${ test.title}`);
+            console.log("\x1b[31m✖", `\x1b[30m${test.title}`);
             console.group();
             console.log(`\x1b[31m${test.error.name}: ${test.error.message}`);
             console.groupEnd();
@@ -113,11 +112,10 @@ async function test() {
         });
 
         printTree(result.suite);
-        if (result.stats.failures > 0){
+        if (result.stats.failures > 0) {
             console.error("\n\x1b[31m✖ Not all tests passed!\n");
             process.exit(1);
         }
-
     } finally {
         console.log("\n\x1b[32m✓ All tests passed!\n");
         driver.quit();

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -35,10 +35,12 @@ function printHelp(message = "") {
 
 const options = commandLineArgs(optionDefinitions);
 
-if ("help" in options) printHelp();
+if ("help" in options)
+    printHelp();
 
 const BROWSER = options?.browser;
-if (!BROWSER) printHelp("No browser specified, use $BROWSER or --browser");
+if (!BROWSER)
+    printHelp("No browser specified, use $BROWSER or --browser");
 
 let capabilities;
 switch (BROWSER) {

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -120,7 +120,7 @@ async function test() {
         }
 
     } finally {
-        console.log("\n\x1b[32m✓ Tests complete\n");
+        console.log("\n\x1b[32m✓ All tests passed!\n");
         driver.quit();
         server.close();
     }

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -76,9 +76,9 @@ function printTree(node) {
     for (const test of node.tests) {
         console.group();
         if (test.state === "passed") {
-            console.log("\x1b[32m✓", `\x1b[30m${test.title}`);
+            console.log("\x1b[32m✓", `\x1b[0m${test.title}`);
         } else {
-            console.log("\x1b[31m✖", `\x1b[30m${test.title}`);
+            console.log("\x1b[31m✖", `\x1b[0m${test.title}`);
             console.group();
             console.log(`\x1b[31m${test.error.name}: ${test.error.message}`);
             console.groupEnd();


### PR DESCRIPTION
Currently, if tests fail when running `npm run test:chrome`, ect we don't get a good reporting in the node console. 
Especially, if a test fails, we don't get any details.

current pass:
![Screenshot 2024-11-05 at 10 47 11 AM](https://github.com/user-attachments/assets/25535496-ae1a-4825-8f7a-f3ef3de28874)

current fail:
![Screenshot 2024-11-05 at 10 47 50 AM](https://github.com/user-attachments/assets/abd16001-4728-4b1c-8f8e-3018834534f9)

A cleanup can give us similar (simplified) reporting, as the browser window displays.

new pass:
![Screenshot 2024-11-05 at 11 25 53 AM](https://github.com/user-attachments/assets/a85dd75a-e0a1-40ba-9146-e51a94da1b1c)

new fail:
![Screenshot 2024-11-05 at 11 25 40 AM](https://github.com/user-attachments/assets/3b7b82de-588a-44e0-9f5d-0b79b49f229b)
