### PR TITLE
split TestInvokerClass into a separate file

### DIFF
--- a/resources/test-invoker.mjs
+++ b/resources/test-invoker.mjs
@@ -1,0 +1,55 @@
+class TestInvoker {
+    constructor(syncCallback, asyncCallback, reportCallback, params) {
+        this._syncCallback = syncCallback;
+        this._asyncCallback = asyncCallback;
+        this._reportCallback = reportCallback;
+        this._params = params;
+    }
+}
+
+export class TimerTestInvoker extends TestInvoker {
+    start() {
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                this._syncCallback();
+                setTimeout(() => {
+                    this._asyncCallback();
+                    requestAnimationFrame(async () => {
+                        await this._reportCallback();
+                        resolve();
+                    });
+                }, 0);
+            }, this._params.waitBeforeSync);
+        });
+    }
+}
+
+export class RAFTestInvoker extends TestInvoker {
+    start() {
+        return new Promise((resolve) => {
+            if (this._params.waitBeforeSync)
+                setTimeout(() => this._scheduleCallbacks(resolve), this._params.waitBeforeSync);
+            else
+                this._scheduleCallbacks(resolve);
+        });
+    }
+
+    _scheduleCallbacks(resolve) {
+        requestAnimationFrame(() => this._syncCallback());
+        requestAnimationFrame(() => {
+            setTimeout(() => {
+                this._asyncCallback();
+                setTimeout(async () => {
+                    await this._reportCallback();
+                    resolve();
+                }, 0);
+            }, 0);
+        });
+    }
+}
+
+export const TEST_INVOKER_LOOKUP = {
+    __proto__: null,
+    timer: TimerTestInvoker,
+    raf: RAFTestInvoker,
+};


### PR DESCRIPTION
To prepare further for the remote workloads / postMessage feature, I'd like to separate out the test invokers from the benchmark-runner. This will reduce duplicate code, since workloads will re-use (import) the same test invoker classes to run the tests themselves. 

Since the test invokers are self-contained now, I am passing in the params object, which the classes rely on.
