### PR TITLE
Tweak NewsSite test step scenarios

### DIFF
--- a/resources/default-tests.mjs
+++ b/resources/default-tests.mjs
@@ -709,32 +709,44 @@ export const DefaultSuites = freezeSuites([
         },
         tests: [
             new BenchmarkTestStep("NavigateToUS", (page) => {
-                for (let i = 0; i < 25; i++) {
-                    page.querySelector("#navbar-dropdown-toggle").click();
-                    page.layout();
-                    page.querySelector("#navbar-dropdown-toggle").click();
-                    page.layout();
-                }
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-navlist-opinion-link").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
                 page.querySelector("#navbar-navlist-us-link").click();
                 page.layout();
             }),
             new BenchmarkTestStep("NavigateToWorld", (page) => {
-                for (let i = 0; i < 25; i++) {
-                    page.querySelector("#navbar-dropdown-toggle").click();
-                    page.layout();
-                    page.querySelector("#navbar-dropdown-toggle").click();
-                    page.layout();
-                }
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-navlist-opinion-link").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
                 page.querySelector("#navbar-navlist-world-link").click();
                 page.layout();
             }),
             new BenchmarkTestStep("NavigateToPolitics", (page) => {
-                for (let i = 0; i < 25; i++) {
-                    page.querySelector("#navbar-dropdown-toggle").click();
-                    page.layout();
-                    page.querySelector("#navbar-dropdown-toggle").click();
-                    page.layout();
-                }
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-navlist-opinion-link").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
                 page.querySelector("#navbar-navlist-politics-link").click();
                 page.layout();
             }),
@@ -749,32 +761,44 @@ export const DefaultSuites = freezeSuites([
         },
         tests: [
             new BenchmarkTestStep("NavigateToUS", (page) => {
-                for (let i = 0; i < 25; i++) {
-                    page.querySelector("#navbar-dropdown-toggle").click();
-                    page.layout();
-                    page.querySelector("#navbar-dropdown-toggle").click();
-                    page.layout();
-                }
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-navlist-opinion-link").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
                 page.querySelector("#navbar-navlist-us-link").click();
                 page.layout();
             }),
             new BenchmarkTestStep("NavigateToWorld", (page) => {
-                for (let i = 0; i < 25; i++) {
-                    page.querySelector("#navbar-dropdown-toggle").click();
-                    page.layout();
-                    page.querySelector("#navbar-dropdown-toggle").click();
-                    page.layout();
-                }
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-navlist-opinion-link").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
                 page.querySelector("#navbar-navlist-world-link").click();
                 page.layout();
             }),
             new BenchmarkTestStep("NavigateToPolitics", (page) => {
-                for (let i = 0; i < 25; i++) {
-                    page.querySelector("#navbar-dropdown-toggle").click();
-                    page.layout();
-                    page.querySelector("#navbar-dropdown-toggle").click();
-                    page.layout();
-                }
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-navlist-opinion-link").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
+                page.querySelector("#navbar-dropdown-toggle").click();
+                page.layout();
                 page.querySelector("#navbar-navlist-politics-link").click();
                 page.layout();
             }),


### PR DESCRIPTION
This proof of concept illustrates potential tweaks to the test steps for the NewsSite workload. It introduces an extra navigation to a new tab instead of repeatedly toggling the drop-down menu.

![image](https://github.com/user-attachments/assets/f83789ca-12da-476f-885e-13f47351eb08)


