### PR TITLE
Avoid measurement dead-spot between sync and async phase

### DIFF
--- a/resources/test-runner.mjs
+++ b/resources/test-runner.mjs
@@ -24,7 +24,7 @@ export class TestRunner {
         const testName = this.#test.name;
         const syncStartLabel = `${suiteName}.${testName}-start`;
         const syncEndLabel = `${suiteName}.${testName}-sync-end`;
-        const asyncStartLabel = `${suiteName}.${testName}-async-start`;
+        const asyncStartLabel = syncEndLabel;
         const asyncEndLabel = `${suiteName}.${testName}-async-end`;
 
         let syncTime;
@@ -47,9 +47,7 @@ export class TestRunner {
             performance.mark(syncEndLabel);
 
             syncTime = syncEndTime - syncStartTime;
-
-            performance.mark(asyncStartLabel);
-            asyncStartTime = performance.now();
+            asyncStartTime = syncEndTime;
         };
         const measureAsync = () => {
             const bodyReference = this.#frame ? this.#frame.contentDocument.body : document.body;


### PR DESCRIPTION
We could potentially miss a `gc` between the `performance.mark` calls for `syncEndTime` and `asyncStartTime`.

This PR changes the code to reuse the sync end times and marker for the async start.
This means we'll now also measure one additional `performance.mark` call.

Summary 5 runs:
```
browser                                     Google Chrome          Firefox                Safari
version                                     131.0.6778.140         133.0                  18.1.1 (20619.2.8.11.12)
Score Before                                32.07 ± 0.67%          27.228 ± 0.13%         32.75 ± 0.48%
Score  After                                31.14 ± 0.54%          26.10 ± 0.79%          30.36 ± 0.68%
```

I have to re-run the detailed measurements tonight when my machine is not in use to reduce noise.