### PR TITLE
Make the progress bar track indivisual suites, not indivisual steps.

### DIFF
--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -93,10 +93,8 @@ class MainBenchmarkClient {
         this._isRunning = true;
 
         const enabledSuites = Suites.filter((suite) => !suite.disabled);
-        const totalSubtestsCount = enabledSuites.reduce((testsCount, suite) => {
-            return testsCount + suite.tests.length;
-        }, 0);
-        this.stepCount = params.iterationCount * totalSubtestsCount;
+        const totalSuitesCount = enabledSuites.length;
+        this.stepCount = params.iterationCount * totalSuitesCount;
         this._progressCompleted.max = this.stepCount;
         this.suitesCount = enabledSuites.length;
         const runner = new BenchmarkRunner(Suites, this);
@@ -121,7 +119,7 @@ class MainBenchmarkClient {
             await this._awaitNextStep(suite, test);
     }
 
-    didRunTest() {
+    didFinishSuite() {
         this._finishedTestCount++;
         this._progressCompleted.value = this._finishedTestCount;
     }

--- a/resources/suite-runner.mjs
+++ b/resources/suite-runner.mjs
@@ -60,6 +60,8 @@ export class SuiteRunner {
 
         performance.measure(`suite-${suiteName}`, suiteStartLabel, suiteEndLabel);
         this._validateSuiteTotal();
+        if (this.#client?.didFinishSuite)
+            await this.#client.didFinishSuite(this.#suite);
     }
 
     _validateSuiteTotal() {


### PR DESCRIPTION
This is needed to allow for remote workloads.