### PR TITLE
Delete the timer based measurement since we've switched over to

### DIFF
--- a/resources/developer-mode.mjs
+++ b/resources/developer-mode.mjs
@@ -18,7 +18,6 @@ export function createDeveloperModeContainer() {
     const settings = document.createElement("div");
     settings.className = "settings";
     settings.append(createUIForIterationCount());
-    settings.append(createUIForMeasurementMethod());
     settings.append(createUIForWarmupSuite());
     settings.append(createUIForWarmupBeforeSync());
     settings.append(createUIForSyncStepDelay());
@@ -38,12 +37,6 @@ function span(text) {
     const span = document.createElement("span");
     span.textContent = text;
     return span;
-}
-
-function createUIForMeasurementMethod() {
-    return createCheckboxUI("rAF timing", params.measurementMethod === "raf", (isChecked) => {
-        params.measurementMethod = isChecked ? "raf" : "timer";
-    });
 }
 
 function createUIForWarmupSuite() {
@@ -262,7 +255,7 @@ function updateURL() {
         }
     }
 
-    const defaultParamKeys = ["measurementMethod", "iterationCount", "useWarmupSuite", "warmupBeforeSync", "waitBeforeSync"];
+    const defaultParamKeys = ["iterationCount", "useWarmupSuite", "warmupBeforeSync", "waitBeforeSync"];
     for (const paramKey of defaultParamKeys) {
         if (params[paramKey] !== defaultParams[paramKey])
             url.searchParams.set(paramKey, params[paramKey]);

--- a/resources/shared/params.mjs
+++ b/resources/shared/params.mjs
@@ -15,7 +15,7 @@ export class Params {
     // Change how a test measurement is triggered and async time is measured:
     // "timer": The classic (as in Speedometer 2.x) way using setTimeout
     // "raf":   Using rAF callbacks, both for triggering the sync part and for measuring async time.
-    measurementMethod = "raf"; // or "timer"
+    measurementMethod = "raf";
     // Wait time before the sync step in ms.
     waitBeforeSync = 0;
     // Warmup time before the sync step in ms.
@@ -122,8 +122,8 @@ export class Params {
         if (!searchParams.has("measurementMethod"))
             return defaultParams.measurementMethod;
         const measurementMethod = searchParams.get("measurementMethod");
-        if (measurementMethod !== "timer" && measurementMethod !== "raf")
-            throw new Error(`Invalid measurement method: '${measurementMethod}', must be either 'raf' or 'timer'.`);
+        if (measurementMethod !== "raf")
+            throw new Error(`Invalid measurement method: '${measurementMethod}', must be 'raf'.`);
         searchParams.delete("measurementMethod");
         return measurementMethod;
     }

--- a/resources/shared/test-invoker.mjs
+++ b/resources/shared/test-invoker.mjs
@@ -7,23 +7,6 @@ class TestInvoker {
     }
 }
 
-export class TimerTestInvoker extends TestInvoker {
-    start() {
-        return new Promise((resolve) => {
-            setTimeout(() => {
-                this._syncCallback();
-                setTimeout(() => {
-                    this._asyncCallback();
-                    requestAnimationFrame(async () => {
-                        const result = await this._reportCallback();
-                        resolve(result);
-                    });
-                }, 0);
-            }, this._params.waitBeforeSync);
-        });
-    }
-}
-
 export class RAFTestInvoker extends TestInvoker {
     start() {
         return new Promise((resolve) => {
@@ -50,6 +33,5 @@ export class RAFTestInvoker extends TestInvoker {
 
 export const TEST_INVOKER_LOOKUP = {
     __proto__: null,
-    timer: TimerTestInvoker,
     raf: RAFTestInvoker,
 };


### PR DESCRIPTION
requestAnimationFrame based measurement for 3.0 and found no issues.