### PR TITLE
Add a netlify configuration file

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    cross-origin-embedder-policy = "require-corp"
+    cross-origin-opener-policy = "same-origin"
+    X-Frame-Options = "SAMEORIGIN"
+    x-content-type-options = "nosniff"


### PR DESCRIPTION
This configures the same headers as for https://browserbench.org/Speedometer3.0/.

I prefered to use `netlify.toml` over a `_headers` file to make it more obvious what this file is for.

Documentation is in https://docs.netlify.com/routing/headers/#syntax-for-the-netlify-configuration-file

Note that this doesn't apply until it's committed to the main branch (I think).