### PR TITLE
Perf-Dashboard.Render sync phase sets location.hash, but the actual DOM (#488)

### DIFF
--- a/resources/perf.webkit.org/public/v3/bundled-scripts.js
+++ b/resources/perf.webkit.org/public/v3/bundled-scripts.js
@@ -2608,8 +2608,8 @@ url(routeName,state)
 _updateURLState()
 {this._historyTimer=null;console.assert(this._currentPage);const currentPage=this._currentPage;this._hash=this._serializeToHash(currentPage.routeName(),currentPage.serializeState());location.hash=this._hash;}
 _hashDidChange()
-{if(unescape(location.hash)==this._hash)
-return;this.route();this._hash=null;}
+{let unescapedHash=unescape(location.hash);if(unescapedHash==this._hash)
+return;this.route();this._hash=unescapedHash;}
 _serializeToHash(route,state)
 {const params=[];for(const key in state)
 params.push(key+'='+this._serializeHashQueryValue(state[key]));const query=params.length?('?'+params.join('&')):'';return`#/${route}${query}`;}

--- a/resources/perf.webkit.org/public/v3/index.html
+++ b/resources/perf.webkit.org/public/v3/index.html
@@ -80,6 +80,7 @@ Run tools/bundle-v3-scripts to speed up the load time for production.`);
         function openCharts()
         {
             location.hash = '/charts/?since=1678991819934\u0026paneList=((55-1649-53731881-null-(5-2.5-500))-(55-1407-null-null-(5-2.5-500))-(55-1648-null-null-(5-2.5-500))-(55-1974-null-null-(5-2.5-500)))';
+            window.onhashchange();
         }
 
         function mockAPIs() {

--- a/resources/perf.webkit.org/public/v3/pages/page-router.js
+++ b/resources/perf.webkit.org/public/v3/pages/page-router.js
@@ -97,10 +97,11 @@ class PageRouter {
 
     _hashDidChange()
     {
-        if (unescape(location.hash) == this._hash)
+        let unescapedHash = unescape(location.hash);
+        if (unescapedHash == this._hash)
             return;
         this.route();
-        this._hash = null;
+        this._hash = unescapedHash;
     }
 
     _serializeToHash(route, state)


### PR DESCRIPTION
modifications happen asynchronously in the onhashchange() callback.

This results in nothing interesting being measured during the sync phase, and the resulting rendering update (during the async phase) not including the change.

Change the test to manually and synchronously trigger the onhashchange() callback, and change the page content to detect and omit duplicate events.