### PR TITLE
Release/3.1 - Use 8080 as default address for local test server

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "license": "SEE LICENSE IN LICENSE",
     "scripts": {
         "dev": "http-server ./ -p 8080 -c-1 --cors",
-        "server": "http-server ./ -p 8080--cors",
+        "server": "http-server ./ -p 8080 --cors",
         "lint:check": "eslint **/*.{js,mjs,jsx,ts,tsx}",
         "lint:fix": "eslint \"**/*.{js,mjs,jsx,ts,tsx}\" --fix",
         "pretty:check": "prettier --check ./",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     },
     "license": "SEE LICENSE IN LICENSE",
     "scripts": {
-        "dev": "http-server ./ -p 7000 -c-1 --cors",
-        "server": "http-server ./ -p 7000 --cors",
+        "dev": "http-server ./ -p 8080 -c-1 --cors",
+        "server": "http-server ./ -p 8080--cors",
         "lint:check": "eslint **/*.{js,mjs,jsx,ts,tsx}",
         "lint:fix": "eslint \"**/*.{js,mjs,jsx,ts,tsx}\" --fix",
         "pretty:check": "prettier --check ./",


### PR DESCRIPTION
We've changed this to 8080 on the main branch already, would be nice to have the same for easier local testing in the future.