### PR TITLE
Release/3.1 - Ensure the benchmark version text in the index page title

### DIFF
--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -389,7 +389,7 @@ class MainBenchmarkClient {
     _updateDocumentTitle(hash) {
         const maybeSection = document.querySelector(hash);
         const sectionTitle = maybeSection?.getAttribute("data-title") ?? "";
-        document.title = `Speedometer 3 ${sectionTitle}`.trimEnd();
+        document.title = `Speedometer 3.1 ${sectionTitle}`.trimEnd();
     }
 
     _removeLocationHash() {


### PR DESCRIPTION
Ensure the document title when visiting the main page for version 3.1:

Before
![image](https://github.com/user-attachments/assets/4f9112d5-0f9b-41da-b09f-253656a8fa24)

After
![image](https://github.com/user-attachments/assets/5cd96129-27c6-47c4-a840-adad2ea02f6c)
