### PR TITLE
Customize Force Layout

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -23,6 +23,7 @@ function getParent(lookupStartNode, path) {
 class Page {
     constructor(frame) {
         this._frame = frame;
+        this._leakedLayout = {};
     }
 
     getLocalStorage() {
@@ -30,8 +31,13 @@ class Page {
     }
 
     layout() {
-        const body = this._frame.contentDocument.body.getBoundingClientRect();
-        this.layout.e = document.elementFromPoint((body.width / 2) | 0, (body.height / 2) | 0);
+        const body = this._frame ? this._frame.contentDocument.body : document.body;
+        const bodyRect = body.getBoundingClientRect();
+        if (params.layoutMode === "getBoundingClientRect")
+            this._leakedLayout.sum = bodyRect.width;
+        if (params.layoutMode === "elementFromPoint")
+            this._leakedLayout.element = document.elementFromPoint((bodyRect.width / 2) | 0, (bodyRect.height / 2) | 0);
+        return bodyRect;
     }
 
     async waitForElement(selector) {

--- a/resources/developer-mode.mjs
+++ b/resources/developer-mode.mjs
@@ -1,5 +1,5 @@
 import { Suites, Tags } from "./tests.mjs";
-import { params, defaultParams, LAYOUT_MODES } from "./shared/params.mjs";
+import { params, LAYOUT_MODES } from "./shared/params.mjs";
 
 export function createDeveloperModeContainer() {
     const container = document.createElement("div");

--- a/resources/developer-mode.mjs
+++ b/resources/developer-mode.mjs
@@ -1,5 +1,5 @@
 import { Suites, Tags } from "./tests.mjs";
-import { params, defaultParams, LAYOUT_MODE } from "./shared/params.mjs";
+import { params, defaultParams, LAYOUT_MODES } from "./shared/params.mjs";
 
 export function createDeveloperModeContainer() {
     const container = document.createElement("div");
@@ -109,7 +109,7 @@ function createTimeRangeUI(labelText, paramKey, unit = "ms", min = 0, max = 1000
 }
 
 function createUIForLayoutMode() {
-    return createSelectUI("Force layout mode", params.layoutMode, LAYOUT_MODE, (value) => {
+    return createSelectUI("Force layout mode", params.layoutMode, LAYOUT_MODES, (value) => {
         params.layoutMode = value;
     });
 }

--- a/resources/developer-mode.mjs
+++ b/resources/developer-mode.mjs
@@ -289,47 +289,7 @@ function updateURL() {
     updateParamsSuitesAndTags();
 
     const url = new URL(window.location.href);
-<<<<<<< HEAD
-
-    url.searchParams.delete("tags");
-    url.searchParams.delete("suites");
-    url.searchParams.delete("suite");
-
-    if (params.tags.length)
-        url.searchParams.set("tags", params.tags.join(","));
-    else if (params.suites.length)
-        url.searchParams.set("suites", params.suites.join(","));
-
-    const defaultParamKeys = ["iterationCount", "useWarmupSuite", "warmupBeforeSync", "waitBeforeSync", "useAsyncSteps", "layoutMode"];
-    for (const paramKey of defaultParamKeys) {
-        if (params[paramKey] !== defaultParams[paramKey])
-            url.searchParams.set(paramKey, params[paramKey]);
-        else
-            url.searchParams.delete(paramKey);
-    }
-
-||||||| dd661c03
-
-    url.searchParams.delete("tags");
-    url.searchParams.delete("suites");
-    url.searchParams.delete("suite");
-
-    if (params.tags.length)
-        url.searchParams.set("tags", params.tags.join(","));
-    else if (params.suites.length)
-        url.searchParams.set("suites", params.suites.join(","));
-
-    const defaultParamKeys = ["iterationCount", "useWarmupSuite", "warmupBeforeSync", "waitBeforeSync", "useAsyncSteps"];
-    for (const paramKey of defaultParamKeys) {
-        if (params[paramKey] !== defaultParams[paramKey])
-            url.searchParams.set(paramKey, params[paramKey]);
-        else
-            url.searchParams.delete(paramKey);
-    }
-
-=======
     url.search = params.toSearchParams();
->>>>>>> main
     // Only push state if changed
     if (url.href !== window.location.href)
         window.history.pushState({}, "", url);

--- a/resources/developer-mode.mjs
+++ b/resources/developer-mode.mjs
@@ -1,5 +1,5 @@
 import { Suites, Tags } from "./tests.mjs";
-import { params, defaultParams, LAYOUT_MODE,} from "./shared/params.mjs";
+import { params, defaultParams, LAYOUT_MODE } from "./shared/params.mjs";
 
 export function createDeveloperModeContainer() {
     const container = document.createElement("div");
@@ -121,7 +121,7 @@ function createSelectUI(labelValue, initialValue, choices, paramsUpdateCallback)
         updateURL();
     };
 
-    choices.forEach(choice => {
+    choices.forEach((choice) => {
         const option = new Option(choice, choice);
         select.add(option);
     });

--- a/resources/developer-mode.mjs
+++ b/resources/developer-mode.mjs
@@ -1,5 +1,5 @@
 import { Suites, Tags } from "./tests.mjs";
-import { params, defaultParams } from "./shared/params.mjs";
+import { params, defaultParams, LAYOUT_MODE,} from "./shared/params.mjs";
 
 export function createDeveloperModeContainer() {
     const container = document.createElement("div");
@@ -22,6 +22,7 @@ export function createDeveloperModeContainer() {
     settings.append(createUIForWarmupBeforeSync());
     settings.append(createUIForSyncStepDelay());
     settings.append(createUIForAsyncSteps());
+    settings.append(createUIForLayoutMode());
 
     content.append(document.createElement("hr"));
     content.append(settings);
@@ -103,6 +104,31 @@ function createTimeRangeUI(labelText, paramKey, unit = "ms", min = 0, max = 1000
         params[paramKey] = parseInt(range.value);
         updateURL();
     };
+
+    return label;
+}
+
+function createUIForLayoutMode() {
+    return createSelectUI("Force layout mode", params.layoutMode, LAYOUT_MODE, (value) => {
+        params.layoutMode = value;
+    });
+}
+
+function createSelectUI(labelValue, initialValue, choices, paramsUpdateCallback) {
+    const select = document.createElement("select");
+    select.onchange = () => {
+        paramsUpdateCallback(select.value);
+        updateURL();
+    };
+
+    choices.forEach(choice => {
+        const option = new Option(choice, choice);
+        select.add(option);
+    });
+    select.value = initialValue;
+
+    const label = document.createElement("label");
+    label.append(span(labelValue), select);
 
     return label;
 }
@@ -273,7 +299,7 @@ function updateURL() {
     else if (params.suites.length)
         url.searchParams.set("suites", params.suites.join(","));
 
-    const defaultParamKeys = ["iterationCount", "useWarmupSuite", "warmupBeforeSync", "waitBeforeSync", "useAsyncSteps"];
+    const defaultParamKeys = ["iterationCount", "useWarmupSuite", "warmupBeforeSync", "waitBeforeSync", "useAsyncSteps", "layoutMode"];
     for (const paramKey of defaultParamKeys) {
         if (params[paramKey] !== defaultParams[paramKey])
             url.searchParams.set(paramKey, params[paramKey]);

--- a/resources/shared/helpers.mjs
+++ b/resources/shared/helpers.mjs
@@ -24,8 +24,7 @@ export function getAllElements(selector, path = [], lookupStartNode = document) 
 }
 
 export function forceLayout(body, layoutMode = "elementFromPoint") {
-    if (body !== undefined)
-        body = document.body;
+    body ??= document.body;
     const rect = body.getBoundingClientRect();
     if (layoutMode === "elementFromPoint")
         return document.elementFromPoint((rect.width / 2) | 0, (rect.height / 2) | 0);

--- a/resources/shared/helpers.mjs
+++ b/resources/shared/helpers.mjs
@@ -24,6 +24,7 @@ export function getAllElements(selector, path = [], lookupStartNode = document) 
 }
 
 export function forceLayout() {
+    // FIXME: sync implementation with Page.prototype.layout().
     const rect = document.body.getBoundingClientRect();
     const e = document.elementFromPoint((rect.width / 2) | 0, (rect.height / 2) | 0);
     return e;

--- a/resources/shared/helpers.mjs
+++ b/resources/shared/helpers.mjs
@@ -1,3 +1,5 @@
+import { isClassElement } from "typescript";
+
 /**
  * Helper Methods
  *
@@ -26,9 +28,12 @@ export function getAllElements(selector, path = [], lookupStartNode = document) 
 export function forceLayout(body, layoutMode = "getBoundingRectAndElementFromPoint") {
     body ??= document.body;
     const rect = body.getBoundingClientRect();
-    if (layoutMode === "getBoundingRectAndElementFromPoint")
-        return document.elementFromPoint((rect.width / 2) | 0, (rect.height / 2) | 0);
-    else if (layoutMode !== "getBoundingClientRect")
-        throw Error(`Invalid layoutMode: ${layoutMode}`);
-    return rect.height;
+    switch (layoutMode) {
+        case "getBoundingRectAndElementFromPoint":
+            return document.elementFromPoint((rect.width / 2) | 0, (rect.height / 2) | 0);
+        case  "getBoundingClientRect":
+            return rect.height;
+        default:
+            throw Error(`Invalid layoutMode: ${layoutMode}`);
+    }
 }

--- a/resources/shared/helpers.mjs
+++ b/resources/shared/helpers.mjs
@@ -23,10 +23,10 @@ export function getAllElements(selector, path = [], lookupStartNode = document) 
     return elements;
 }
 
-export function forceLayout(body, layoutMode = "elementFromPoint") {
+export function forceLayout(body, layoutMode = "getBoundingRectAndElementFromPoint") {
     body ??= document.body;
     const rect = body.getBoundingClientRect();
-    if (layoutMode === "elementFromPoint")
+    if (layoutMode === "getBoundingRectAndElementFromPoint")
         return document.elementFromPoint((rect.width / 2) | 0, (rect.height / 2) | 0);
     return rect.height;
 }

--- a/resources/shared/helpers.mjs
+++ b/resources/shared/helpers.mjs
@@ -28,5 +28,7 @@ export function forceLayout(body, layoutMode = "getBoundingRectAndElementFromPoi
     const rect = body.getBoundingClientRect();
     if (layoutMode === "getBoundingRectAndElementFromPoint")
         return document.elementFromPoint((rect.width / 2) | 0, (rect.height / 2) | 0);
+    else if (layoutMode !== "getBoundingClientRect")
+        throw Error(`Invalid layoutMode: ${layoutMode}`);
     return rect.height;
 }

--- a/resources/shared/helpers.mjs
+++ b/resources/shared/helpers.mjs
@@ -23,9 +23,11 @@ export function getAllElements(selector, path = [], lookupStartNode = document) 
     return elements;
 }
 
-export function forceLayout() {
-    // FIXME: sync implementation with Page.prototype.layout().
-    const rect = document.body.getBoundingClientRect();
-    const e = document.elementFromPoint((rect.width / 2) | 0, (rect.height / 2) | 0);
-    return e;
+export function forceLayout(body, layoutMode = "elementFromPoint") {
+    if (body !== undefined)
+        body = document.body;
+    const rect = body.getBoundingClientRect();
+    if (layoutMode === "elementFromPoint")
+        return document.elementFromPoint((rect.width / 2) | 0, (rect.height / 2) | 0);
+    return rect.height;
 }

--- a/resources/shared/helpers.mjs
+++ b/resources/shared/helpers.mjs
@@ -1,5 +1,3 @@
-import { isClassElement } from "typescript";
-
 /**
  * Helper Methods
  *
@@ -31,7 +29,7 @@ export function forceLayout(body, layoutMode = "getBoundingRectAndElementFromPoi
     switch (layoutMode) {
         case "getBoundingRectAndElementFromPoint":
             return document.elementFromPoint((rect.width / 2) | 0, (rect.height / 2) | 0);
-        case  "getBoundingClientRect":
+        case "getBoundingClientRect":
             return rect.height;
         default:
             throw Error(`Invalid layoutMode: ${layoutMode}`);

--- a/resources/shared/params.mjs
+++ b/resources/shared/params.mjs
@@ -1,4 +1,3 @@
-
 export const LAYOUT_MODE = Object.freeze(["getBoundingClientRect", "elementFromPoint"]);
 
 export class Params {

--- a/resources/shared/params.mjs
+++ b/resources/shared/params.mjs
@@ -1,4 +1,4 @@
-export const LAYOUT_MODE = Object.freeze(["getBoundingClientRect", "elementFromPoint"]);
+export const LAYOUT_MODES = Object.freeze(["getBoundingClientRect", "elementFromPoint"]);
 
 export class Params {
     viewport = {
@@ -29,7 +29,7 @@ export class Params {
     // "generate": generate a random seed
     // <integer>: use the provided integer as a seed
     shuffleSeed = "off";
-    // Choices: ""
+    // Choices: getBoundingClientRect or elementFromPoint
     layoutMode = "getBoundingClientRect";
 
     constructor(searchParams = undefined) {
@@ -59,9 +59,9 @@ export class Params {
         this.useAsyncSteps = this._parseBooleanParam(searchParams, "useAsyncSteps");
         this.waitBeforeSync = this._parseIntParam(searchParams, "waitBeforeSync", 0);
         this.warmupBeforeSync = this._parseIntParam(searchParams, "warmupBeforeSync", 0);
-        this.measurementMethod = this._parseChoiceParam(searchParams, "measurementMethod", ["raf"]);
+        this.measurementMethod = this._parseEnumParam(searchParams, "measurementMethod", ["raf"]);
         this.shuffleSeed = this._parseShuffleSeed(searchParams);
-        this.layoutMode = this._parseChoiceParam(searchParams, "layoutMode", LAYOUT_MODE);
+        this.layoutMode = this._parseEnumParam(searchParams, "layoutMode", LAYOUT_MODES);
 
         const unused = Array.from(searchParams.keys());
         if (unused.length > 0)
@@ -126,12 +126,12 @@ export class Params {
         return tags;
     }
 
-    _parseChoiceParam(searchParams, paramKey, choices) {
+    _parseEnumParam(searchParams, paramKey, enumArray) {
         if (!searchParams.has(paramKey))
             return defaultParams[paramKey];
         const value = searchParams.get(paramKey);
-        if (!choices.includes(value))
-            throw new Error(`Got invalid ${paramKey}: '${value}', choices are ${choices}`);
+        if (!enumArray.includes(value))
+            throw new Error(`Got invalid ${paramKey}: '${value}', choices are ${enumArray}`);
         searchParams.delete(paramKey);
         return value;
     }

--- a/resources/shared/params.mjs
+++ b/resources/shared/params.mjs
@@ -1,4 +1,4 @@
-export const LAYOUT_MODES = Object.freeze(["getBoundingClientRect", "elementFromPoint"]);
+export const LAYOUT_MODES = Object.freeze(["getBoundingClientRect", "getBoundingRectAndElementFromPoint"]);
 
 export class Params {
     viewport = {
@@ -29,8 +29,8 @@ export class Params {
     // "generate": generate a random seed
     // <integer>: use the provided integer as a seed
     shuffleSeed = "off";
-    // Choices: getBoundingClientRect or elementFromPoint
-    layoutMode = "getBoundingClientRect";
+    // Choices: "getBoundingClientRect" or "getBoundingRectAndElementFromPoint"
+    layoutMode = LAYOUT_MODES[0];
     // Measure more workload prepare time.
     measurePrepare = false;
 

--- a/resources/shared/params.mjs
+++ b/resources/shared/params.mjs
@@ -1,3 +1,6 @@
+
+export const LAYOUT_MODE = Object.freeze(["getBoundingClientRect", "elementFromPoint"]);
+
 export class Params {
     viewport = {
         width: 800,
@@ -27,6 +30,8 @@ export class Params {
     // "generate": generate a random seed
     // <integer>: use the provided integer as a seed
     shuffleSeed = "off";
+    // Choices: ""
+    layoutMode = "getBoundingClientRect";
 
     constructor(searchParams = undefined) {
         if (searchParams)
@@ -55,8 +60,9 @@ export class Params {
         this.useAsyncSteps = this._parseBooleanParam(searchParams, "useAsyncSteps");
         this.waitBeforeSync = this._parseIntParam(searchParams, "waitBeforeSync", 0);
         this.warmupBeforeSync = this._parseIntParam(searchParams, "warmupBeforeSync", 0);
-        this.measurementMethod = this._parseMeasurementMethod(searchParams);
+        this.measurementMethod = this._parseChoiceParam(searchParams, "measurementMethod", ["raf"]);
         this.shuffleSeed = this._parseShuffleSeed(searchParams);
+        this.layoutMode = this._parseChoiceParam(searchParams, "layoutMode", LAYOUT_MODE);
 
         const unused = Array.from(searchParams.keys());
         if (unused.length > 0)
@@ -121,14 +127,14 @@ export class Params {
         return tags;
     }
 
-    _parseMeasurementMethod(searchParams) {
-        if (!searchParams.has("measurementMethod"))
-            return defaultParams.measurementMethod;
-        const measurementMethod = searchParams.get("measurementMethod");
-        if (measurementMethod !== "raf")
-            throw new Error(`Invalid measurement method: '${measurementMethod}', must be 'raf'.`);
-        searchParams.delete("measurementMethod");
-        return measurementMethod;
+    _parseChoiceParam(searchParams, paramKey, choices) {
+        if (!searchParams.has(paramKey))
+            return defaultParams[paramKey];
+        const value = searchParams.get(paramKey);
+        if (!choices.includes(value))
+            throw new Error(`Got invalid ${paramKey}: '${value}', choices are ${choices}`);
+        searchParams.delete(paramKey);
+        return value;
     }
 
     _parseShuffleSeed(searchParams) {

--- a/resources/shared/test-runner.mjs
+++ b/resources/shared/test-runner.mjs
@@ -67,12 +67,11 @@ export class TestRunner {
             asyncStartTime = syncEndTime;
         };
         const measureAsync = () => {
-            const bodyReference = this.#frame ? this.#frame.contentDocument.body : document.body;
-            const windowReference = this.#frame ? this.#frame.contentWindow : window;
             // Some browsers don't immediately update the layout for paint.
             // Force the layout here to ensure we're measuring the layout time.
-            const height = bodyReference.getBoundingClientRect().height;
-            windowReference._unusedHeightValue = height; // Prevent dead code elimination.
+            const windowReference = this.#frame ? this.#frame.contentWindow : window;
+            const bodyRect = this.page.layout();
+            windowReference._unusedHeightValue = bodyRect.height; // Prevent dead code elimination.
 
             const asyncEndTime = performance.now();
             performance.mark(asyncEndLabel);

--- a/resources/shared/test-runner.mjs
+++ b/resources/shared/test-runner.mjs
@@ -69,9 +69,7 @@ export class TestRunner {
         const measureAsync = () => {
             // Some browsers don't immediately update the layout for paint.
             // Force the layout here to ensure we're measuring the layout time.
-            const windowReference = this.#frame ? this.#frame.contentWindow : window;
-            const bodyRect = this.page.layout();
-            windowReference._unusedHeightValue = bodyRect.height; // Prevent dead code elimination.
+            this.page.layout();
 
             const asyncEndTime = performance.now();
             performance.mark(asyncEndLabel);


### PR DESCRIPTION
Currently we have two different modes in which we force layout

- `getBoundingClientRect` used by default in the benchmark runner and tests
- `elementFromPoint` used in the remote workloads

This PR adds a new `layoutMode` param to switch between the two modes.