### PR TITLE
Improve deverloper menu and non-standard params table styling

### DIFF
--- a/resources/developer-mode.mjs
+++ b/resources/developer-mode.mjs
@@ -219,12 +219,13 @@ function createSuitesTagsButton(setSuiteEnabled) {
 
 function createUIForRun() {
     const stepTestButton = document.createElement("button");
-    stepTestButton.textContent = "Step Test \u23EF";
+    stepTestButton.className = "step-button";
+    stepTestButton.innerHTML = "Step Test<span>\u23EF</span>";
     stepTestButton.onclick = (event) => {
         globalThis.benchmarkClient.step();
     };
     const startTestButton = document.createElement("button");
-    startTestButton.textContent = "Start Test \u23F5";
+    startTestButton.innerHTML = "Start Test<span>\u23F5</span>";
     startTestButton.onclick = (event) => {
         globalThis.benchmarkClient.start();
     };

--- a/resources/main.css
+++ b/resources/main.css
@@ -287,6 +287,7 @@ button,
 }
 
 .developer-mode-content button {
+    font-size: 16px;
     background: white;
     flex: auto;
     padding: 4px;
@@ -294,8 +295,20 @@ button,
     border: 2px solid rgba(255, 255, 255, 0.5);
     border-radius: 10px;
 }
+
+.developer-mode-content button span {
+    padding-left: 10px;
+    font-size: 25px;
+    line-height: 10px;
+    position: relative;
+    top: 2px;
+}
+
 .developer-mode-content .tag {
     border-radius: 100vh;
+}
+
+.developer-mode-content .step-button {
     color: white;
     background: rgba(255, 255, 255, 0.1);
 }
@@ -546,6 +559,9 @@ section#details .non-standard-params h2 {
 #non-standard-params-table thead th,
 #non-standard-params-table tbody td {
     padding: 0.1em 0.3em;
+}
+#non-standard-params-table tbody td:nth-child(2) {
+    color: var(--highlight);
 }
 
 section#details .all-metric-results {


### PR DESCRIPTION
I very often click on the step instad of the start button and don't immediately see what's the non-standard param value.

- Use tags-style for step-button
- Increase start / step button icon
- Use red highlight color for non-standard params

<img width="487" alt="Screenshot 2025-05-21 at 14 56 45" src="https://github.com/user-attachments/assets/ed862382-51ad-471c-9bf7-41fb766748cb" />
<img width="561" alt="Screenshot 2025-05-21 at 14 56 35" src="https://github.com/user-attachments/assets/618a9493-c1b2-48b5-bb8e-810289f383a9" />
