### PR TITLE
Bump min nodejs version to v22

### DIFF
--- a/resources/charts/package.json
+++ b/resources/charts/package.json
@@ -3,6 +3,10 @@
     "private": true,
     "version": "0.0.0",
     "type": "module",
+    "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=8.19.3"
+    },
     "scripts": {
         "dev": "vite",
         "build": "vite build",

--- a/resources/editors/package.json
+++ b/resources/editors/package.json
@@ -3,6 +3,10 @@
     "private": true,
     "version": "0.0.0",
     "type": "module",
+    "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=8.19.3"
+    },
     "scripts": {
         "dev": "vite",
         "build": "vite build",

--- a/resources/newssite/news-next/package.json
+++ b/resources/newssite/news-next/package.json
@@ -2,6 +2,10 @@
     "name": "news-next",
     "version": "0.1.0",
     "private": true,
+    "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=8.19.3"
+    },
     "scripts": {
         "dev": "next dev",
         "build": "next build",

--- a/resources/newssite/news-nuxt/package.json
+++ b/resources/newssite/news-nuxt/package.json
@@ -23,5 +23,9 @@
         "http-server": "^14.1.1",
         "news-site-css": "file:../news-site-css",
         "uuid": "^9.0.0"
+    },
+    "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=8.19.3"
     }
 }

--- a/resources/newssite/news-site-css/package.json
+++ b/resources/newssite/news-site-css/package.json
@@ -5,7 +5,7 @@
     "author": "Thorsten Kober",
     "license": "ISC",
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "scripts": {

--- a/resources/react-stockcharts/package.json
+++ b/resources/react-stockcharts/package.json
@@ -1,6 +1,10 @@
 {
   "name": "react-stockcharts-bench",
   "private": true,
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=8.19.3"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "rm -rf build && react-scripts build"

--- a/resources/scripts/sanitize-language/package.json
+++ b/resources/scripts/sanitize-language/package.json
@@ -2,5 +2,9 @@
     "name": "sanitize-language",
     "version": "1.0.0",
     "description": "A script to parse files for non-inclusive words.",
-    "main": "index.js"
+    "main": "index.js",
+    "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=8.19.3"
+    }
 }

--- a/resources/shared/package.json
+++ b/resources/shared/package.json
@@ -1,5 +1,9 @@
 {
     "name": "speedometer-utils",
     "version": "1.0.0",
-    "description": "Utility files for Speedometer & Workloads"
+    "description": "Utility files for Speedometer & Workloads",
+    "engines": {
+        "node": ">=18.13.0",
+        "npm": ">=8.19.3"
+    }
 }

--- a/resources/todomvc/architecture-examples/angular-complex/package.json
+++ b/resources/todomvc/architecture-examples/angular-complex/package.json
@@ -4,7 +4,7 @@
     "description": "TodoMVC complex app written with Angular.",
     "private": true,
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "scripts": {

--- a/resources/todomvc/architecture-examples/angular/package.json
+++ b/resources/todomvc/architecture-examples/angular/package.json
@@ -4,7 +4,7 @@
     "description": "TodoMVC app written with Angular.",
     "private": true,
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "scripts": {

--- a/resources/todomvc/architecture-examples/backbone-complex/package.json
+++ b/resources/todomvc/architecture-examples/backbone-complex/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "TodoMVC app written with backbone.",
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "private": true,

--- a/resources/todomvc/architecture-examples/backbone/package.json
+++ b/resources/todomvc/architecture-examples/backbone/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "TodoMVC app written with backbone.",
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "private": true,

--- a/resources/todomvc/architecture-examples/jquery-complex/package.json
+++ b/resources/todomvc/architecture-examples/jquery-complex/package.json
@@ -1,6 +1,10 @@
 {
   "name": "todomvc-jquery-complex",
   "private": true,
+  "engines": {
+    "node": ">=18.13.0",
+    "npm": ">=8.19.3"
+  },
   "scripts": {
     "build": "node scripts/build.js",
     "serve": "http-server ./dist -p 7002 -c-1 --cors"

--- a/resources/todomvc/architecture-examples/jquery/package.json
+++ b/resources/todomvc/architecture-examples/jquery/package.json
@@ -1,6 +1,10 @@
 {
   "name": "todomvc-jquery",
   "private": true,
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=8.19.3"
+  },
   "scripts": {
     "dev": "http-server . -p 7001 -c-1 --cors",
     "build": "node scripts/build.js",

--- a/resources/todomvc/architecture-examples/lit-complex/package.json
+++ b/resources/todomvc/architecture-examples/lit-complex/package.json
@@ -2,7 +2,7 @@
     "name": "lit-complex",
     "private": true,
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "scripts": {

--- a/resources/todomvc/architecture-examples/lit/package.json
+++ b/resources/todomvc/architecture-examples/lit/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "type": "module",
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "scripts": {

--- a/resources/todomvc/architecture-examples/preact-complex/package.json
+++ b/resources/todomvc/architecture-examples/preact-complex/package.json
@@ -4,7 +4,7 @@
     "description": "TodoMVC complex app written with Preact.",
     "private": true,
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "scripts": {

--- a/resources/todomvc/architecture-examples/preact/package.json
+++ b/resources/todomvc/architecture-examples/preact/package.json
@@ -4,7 +4,7 @@
     "description": "TodoMVC app written with Preact.",
     "private": true,
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "scripts": {

--- a/resources/todomvc/architecture-examples/react-complex/package.json
+++ b/resources/todomvc/architecture-examples/react-complex/package.json
@@ -4,7 +4,7 @@
     "description": "TodoMVC app written with React.",
     "private": true,
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "scripts": {

--- a/resources/todomvc/architecture-examples/react-redux-complex/package.json
+++ b/resources/todomvc/architecture-examples/react-redux-complex/package.json
@@ -4,7 +4,7 @@
     "description": "TodoMVC app written with React-Redux.",
     "private": true,
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "scripts": {

--- a/resources/todomvc/architecture-examples/react-redux/package.json
+++ b/resources/todomvc/architecture-examples/react-redux/package.json
@@ -4,7 +4,7 @@
     "description": "TodoMVC app written with React-Redux.",
     "private": true,
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "scripts": {

--- a/resources/todomvc/architecture-examples/react/package.json
+++ b/resources/todomvc/architecture-examples/react/package.json
@@ -4,7 +4,7 @@
     "description": "TodoMVC app written with React.",
     "private": true,
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "scripts": {

--- a/resources/todomvc/architecture-examples/svelte-complex/package.json
+++ b/resources/todomvc/architecture-examples/svelte-complex/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "TodoMVC app written with Svelte.",
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "private": true,

--- a/resources/todomvc/architecture-examples/svelte/package.json
+++ b/resources/todomvc/architecture-examples/svelte/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "TodoMVC app written with Svelte.",
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "private": true,

--- a/resources/todomvc/architecture-examples/vue-complex/package.json
+++ b/resources/todomvc/architecture-examples/vue-complex/package.json
@@ -4,7 +4,7 @@
     "description": "TodoMVC complex app written with Vue.",
     "private": true,
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "scripts": {

--- a/resources/todomvc/architecture-examples/vue/package.json
+++ b/resources/todomvc/architecture-examples/vue/package.json
@@ -4,7 +4,7 @@
     "description": "TodoMVC app written with Vue.",
     "private": true,
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "scripts": {

--- a/resources/todomvc/big-dom-generator/package.json
+++ b/resources/todomvc/big-dom-generator/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "Complex DOM generator to embed TodoMVC in a static HTML page",
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "scripts": {

--- a/resources/todomvc/todomvc-css/package.json
+++ b/resources/todomvc/todomvc-css/package.json
@@ -5,7 +5,7 @@
     "author": "Thorsten Kober",
     "license": "ISC",
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "scripts": {

--- a/resources/todomvc/vanilla-examples/javascript-es5-complex/package.json
+++ b/resources/todomvc/vanilla-examples/javascript-es5-complex/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "TodoMVC app written with JavaScript es5 features.",
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "private": true,

--- a/resources/todomvc/vanilla-examples/javascript-es5/package.json
+++ b/resources/todomvc/vanilla-examples/javascript-es5/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "TodoMVC app written with JavaScript es5 features.",
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "private": true,

--- a/resources/todomvc/vanilla-examples/javascript-es6-webpack-complex/package.json
+++ b/resources/todomvc/vanilla-examples/javascript-es6-webpack-complex/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "TodoMVC app written with JavaScript es6 features.",
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "private": true,

--- a/resources/todomvc/vanilla-examples/javascript-es6-webpack/package.json
+++ b/resources/todomvc/vanilla-examples/javascript-es6-webpack/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "TodoMVC app written with JavaScript es6 features.",
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "private": true,

--- a/resources/todomvc/vanilla-examples/javascript-web-components-complex/package.json
+++ b/resources/todomvc/vanilla-examples/javascript-web-components-complex/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "TodoMVC complex app written with JavaScript using web components.",
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "private": true,

--- a/resources/todomvc/vanilla-examples/javascript-web-components/package.json
+++ b/resources/todomvc/vanilla-examples/javascript-web-components/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "TodoMVC app written with JavaScript using web components.",
     "engines": {
-        "node": ">=18.13.0",
+        "node": ">=22.0.0",
         "npm": ">=8.19.3"
     },
     "private": true,


### PR DESCRIPTION
We already had a min version in the top-level package.json file, but it was not the same for all workloads.
This can easily causes issues when having to regenerate individual workloads where the nodejs version is accidentally not matching the previous version used for created the `dist` output.