### PR TITLE
Consistent naming: use step instead of test

### DIFF
--- a/experimental/javascript-wc-indexeddb/scripts/build.js
+++ b/experimental/javascript-wc-indexeddb/scripts/build.js
@@ -98,7 +98,7 @@ const filesToMove = [
     { src: "node_modules/todomvc-css/dist/todo-item.constructable.js", dest: "./dist/styles/todo-item.constructable.js" },
     { src: "node_modules/dexie/dist/modern/dexie.mjs", dest: "./dist/libs/dexie.mjs" },
     { src: "node_modules/speedometer-utils/test-invoker.mjs", dest: "./dist/src/speedometer-utils/test-invoker.mjs" },
-    { src: "node_modules/speedometer-utils/test-runner.mjs", dest: "./dist/src/speedometer-utils/test-runner.mjs" },
+    { src: "node_modules/speedometer-utils/step-runner.mjs", dest: "./dist/src/speedometer-utils/step-runner.mjs" },
     { src: "node_modules/speedometer-utils/params.mjs", dest: "./dist/src/speedometer-utils/params.mjs" },
     { src: "src/speedometer-utils/benchmark.mjs", dest: "./dist/src/speedometer-utils/benchmark.mjs" },
     { src: "node_modules/speedometer-utils/helpers.mjs", dest: "./dist/src/speedometer-utils/helpers.mjs" },

--- a/resources/shared/benchmark.mjs
+++ b/resources/shared/benchmark.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable no-case-declarations */
-import { TestRunner } from "./test-runner.mjs";
+import { StepRunner } from "./step-runner.mjs";
 import { Params } from "./params.mjs";
 
 /**
@@ -13,9 +13,9 @@ export class BenchmarkStep {
         this.run = run;
     }
 
-    async runAndRecordStep(params, suite, test, callback) {
-        const testRunner = new TestRunner(null, null, params, suite, test, callback);
-        const result = await testRunner.runTest();
+    async runAndRecordStep(params, suite, step, callback) {
+        const stepRunner = new StepRunner(null, null, params, suite, step, callback);
+        const result = await stepRunner.runStep();
         return result;
     }
 }
@@ -31,7 +31,7 @@ export class BenchmarkSuite {
         this.steps = steps;
     }
 
-    record(_test, syncTime, asyncTime) {
+    record(_step, syncTime, asyncTime) {
         const total = syncTime + asyncTime;
         const results = {
             tests: { Sync: syncTime, Async: asyncTime },

--- a/resources/shared/step-runner.mjs
+++ b/resources/shared/step-runner.mjs
@@ -1,18 +1,18 @@
 import { TEST_INVOKER_LOOKUP } from "./test-invoker.mjs";
 import { forceLayout } from "./helpers.mjs";
 
-export class TestRunner {
+export class StepRunner {
     #frame;
     #page;
     #params;
     #suite;
-    #test;
+    #step;
     #callback;
     #type;
 
-    constructor(frame, page, params, suite, test, callback, type) {
+    constructor(frame, page, params, suite, step, callback, type) {
         this.#suite = suite;
-        this.#test = test;
+        this.#step = step;
         this.#params = params;
         this.#callback = callback;
         this.#page = page;
@@ -24,21 +24,21 @@ export class TestRunner {
         return this.#page;
     }
 
-    get test() {
-        return this.#test;
+    get step() {
+        return this.#step;
     }
 
-    _runSyncStep(test, page) {
-        test.run(page);
+    _runSyncStep(step, page) {
+        step.run(page);
     }
 
-    async runTest() {
+    async runStep() {
         // Prepare all mark labels outside the measuring loop.
         const suiteName = this.#suite.name;
-        const testName = this.#test.name;
-        const syncStartLabel = `${suiteName}.${testName}-start`;
-        const syncEndLabel = `${suiteName}.${testName}-sync-end`;
-        const asyncEndLabel = `${suiteName}.${testName}-async-end`;
+        const stepName = this.#step.name;
+        const syncStartLabel = `${suiteName}.${stepName}-start`;
+        const syncEndLabel = `${suiteName}.${stepName}-sync-end`;
+        const asyncEndLabel = `${suiteName}.${stepName}-async-end`;
 
         let syncTime;
         let asyncStartTime;
@@ -57,9 +57,9 @@ export class TestRunner {
             const syncStartTime = performance.now();
 
             if (this.#type === "async")
-                await this._runSyncStep(this.test, this.page);
+                await this._runSyncStep(this.step, this.page);
             else
-                this._runSyncStep(this.test, this.page);
+                this._runSyncStep(this.step, this.page);
 
             const mark = performance.mark(syncEndLabel);
             const syncEndTime = mark.startTime;
@@ -85,11 +85,11 @@ export class TestRunner {
 
             if (this.#params.warmupBeforeSync)
                 performance.measure("warmup", "warmup-start", "warmup-end");
-            performance.measure(`${suiteName}.${testName}-sync`, syncStartLabel, syncEndLabel);
-            performance.measure(`${suiteName}.${testName}-async`, syncEndLabel, asyncEndLabel);
+            performance.measure(`${suiteName}.${stepName}-sync`, syncStartLabel, syncEndLabel);
+            performance.measure(`${suiteName}.${stepName}-async`, syncEndLabel, asyncEndLabel);
         };
 
-        const report = () => this.#callback(this.#test, syncTime, asyncTime);
+        const report = () => this.#callback(this.#step, syncTime, asyncTime);
         const invokerType = this.#suite.type === "async" || this.#params.useAsyncSteps ? "async" : this.#params.measurementMethod;
         const invokerClass = TEST_INVOKER_LOOKUP[invokerType];
         const invoker = new invokerClass(runSync, measureAsync, report, this.#params);
@@ -98,19 +98,19 @@ export class TestRunner {
     }
 }
 
-export class AsyncTestRunner extends TestRunner {
-    constructor(frame, page, params, suite, test, callback, type) {
-        super(frame, page, params, suite, test, callback, type);
+export class AsyncStepRunner extends StepRunner {
+    constructor(frame, page, params, suite, step, callback, type) {
+        super(frame, page, params, suite, step, callback, type);
     }
 
-    async _runSyncStep(test, page) {
-        await test.run(page);
+    async _runSyncStep(step, page) {
+        await step.run(page);
     }
 }
 
-export const TEST_RUNNER_LOOKUP = {
+export const STEP_RUNNER_LOOKUP = {
     __proto__: null,
-    default: TestRunner,
-    async: AsyncTestRunner,
-    remote: TestRunner,
+    default: StepRunner,
+    async: AsyncStepRunner,
+    remote: StepRunner,
 };

--- a/resources/suite-runner.mjs
+++ b/resources/suite-runner.mjs
@@ -1,4 +1,4 @@
-import { TEST_RUNNER_LOOKUP } from "./shared/test-runner.mjs";
+import { STEP_RUNNER_LOOKUP } from "./shared/step-runner.mjs";
 import { WarmupSuite } from "./benchmark-runner.mjs";
 
 export class SuiteRunner {
@@ -73,14 +73,14 @@ export class SuiteRunner {
         const suiteEndLabel = `suite-${suiteName}-end`;
 
         performance.mark(suiteStartLabel);
-        for (const test of this.#suite.tests) {
+        for (const step of this.#suite.tests) {
             if (this.#client?.willRunTest)
-                await this.#client.willRunTest(this.#suite, test);
+                await this.#client.willRunTest(this.#suite, step);
 
-            const testRunnerType = this.#suite.type ?? this.params.useAsyncSteps ? "async" : "default";
-            const testRunnerClass = TEST_RUNNER_LOOKUP[testRunnerType];
-            const testRunner = new testRunnerClass(this.#frame, this.#page, this.#params, this.#suite, test, this._recordTestResults, testRunnerType);
-            await testRunner.runTest();
+            const stepRunnerType = this.#suite.type ?? this.params.useAsyncSteps ? "async" : "default";
+            const stepRunnerClass = STEP_RUNNER_LOOKUP[stepRunnerType];
+            const stepRunner = new stepRunnerClass(this.#frame, this.#page, this.#params, this.#suite, step, this._recordTestResults, stepRunnerType);
+            await stepRunner.runStep();
         }
         performance.mark(suiteEndLabel);
 
@@ -110,13 +110,13 @@ export class SuiteRunner {
         });
     }
 
-    _recordTestResults = async (test, syncTime, asyncTime) => {
+    _recordTestResults = async (step, syncTime, asyncTime) => {
         // Skip reporting updates for the warmup suite.
         if (this.#suite === WarmupSuite)
             return;
 
         let total = syncTime + asyncTime;
-        this.#suiteResults.tests[test.name] = {
+        this.#suiteResults.tests[step.name] = {
             tests: { Sync: syncTime, Async: asyncTime },
             total: total,
         };

--- a/resources/todomvc/vanilla-examples/javascript-web-components/scripts/build.js
+++ b/resources/todomvc/vanilla-examples/javascript-web-components/scripts/build.js
@@ -97,7 +97,7 @@ const filesToMove = [
     { src: "node_modules/todomvc-css/dist/todo-list.constructable.js", dest: "./dist/styles/todo-list.constructable.js" },
     { src: "node_modules/todomvc-css/dist/todo-item.constructable.js", dest: "./dist/styles/todo-item.constructable.js" },
     { src: "node_modules/speedometer-utils/test-invoker.mjs", dest: "./dist/src/speedometer-utils/test-invoker.mjs" },
-    { src: "node_modules/speedometer-utils/test-runner.mjs", dest: "./dist/src/speedometer-utils/test-runner.mjs" },
+    { src: "node_modules/speedometer-utils/step-runner.mjs", dest: "./dist/src/speedometer-utils/step-runner.mjs" },
     { src: "node_modules/speedometer-utils/params.mjs", dest: "./dist/src/speedometer-utils/params.mjs" },
     { src: "node_modules/speedometer-utils/benchmark.mjs", dest: "./dist/src/speedometer-utils/benchmark.mjs" },
     { src: "node_modules/speedometer-utils/helpers.mjs", dest: "./dist/src/speedometer-utils//helpers.mjs" },

--- a/tests/unittests/benchmark-runner.mjs
+++ b/tests/unittests/benchmark-runner.mjs
@@ -1,6 +1,6 @@
 import { BenchmarkRunner } from "../../resources/benchmark-runner.mjs";
 import { SuiteRunner } from "../../resources/suite-runner.mjs";
-import { TestRunner } from "../../resources/shared/test-runner.mjs";
+import { StepRunner } from "../../resources/shared/step-runner.mjs";
 import { defaultParams } from "../../resources/shared/params.mjs";
 
 function TEST_FIXTURE(name) {
@@ -147,7 +147,7 @@ describe("BenchmarkRunner", () => {
             before(async () => {
                 _prepareSuiteSpy = spy(SuiteRunner.prototype, "_prepareSuite");
                 _loadFrameStub = stub(SuiteRunner.prototype, "_loadFrame").callsFake(async () => null);
-                _runTestStub = stub(TestRunner.prototype, "runTest").callsFake(async () => null);
+                _runTestStub = stub(StepRunner.prototype, "runStep").callsFake(async () => null);
                 _validateSuiteResultsStub = stub(SuiteRunner.prototype, "_validateSuiteResults").callsFake(async () => null);
                 performanceMarkSpy = spy(window.performance, "mark");
                 _suitePrepareSpy = spy(suite, "prepare");
@@ -200,7 +200,7 @@ describe("BenchmarkRunner", () => {
 
                 // SuiteRunner adds 2 marks.
                 // Suite used here contains 3 tests.
-                // Each TestRunner adds 3 marks.
+                // Each StepRunner adds 3 marks.
                 expect(performanceMarkSpy.callCount).to.equal(11);
             });
         });


### PR DESCRIPTION
We use step and test interchangeably which is rathe confusing.
This PR changes the runner code to use step eclusiively.