### PR TITLE
Improve workload stepping in developerMode

### DIFF
--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -43,7 +43,7 @@ class MainBenchmarkClient {
         this._steppingPromise = new Promise((resolve) => {
             this._steppingResolver = resolve;
         });
-        if (this._isStepping())
+        if (currentSteppingResolver)
             currentSteppingResolver();
         if (!this._isRunning) {
             this._startBenchmark();
@@ -55,7 +55,8 @@ class MainBenchmarkClient {
         const currentSteppingResolver = this._steppingResolver;
         this._steppingPromise = null;
         this._steppingResolver = null;
-        currentSteppingResolver();
+        if (currentSteppingResolver)
+            currentSteppingResolver();
     }
 
     async _awaitNextStep(suite, test) {
@@ -127,9 +128,11 @@ class MainBenchmarkClient {
             await this._awaitNextStep(suite, test);
     }
 
-    didFinishSuite() {
+    async didFinishSuite(suite) {
         this._finishedTestCount++;
         this._progressCompleted.value = this._finishedTestCount;
+        if (this._steppingPromise)
+            await this._awaitNextStep(suite, { name: "Finished" });
     }
 
     didRunSuites(measuredValues) {

--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -43,8 +43,7 @@ class MainBenchmarkClient {
         this._steppingPromise = new Promise((resolve) => {
             this._steppingResolver = resolve;
         });
-        if (currentSteppingResolver)
-            currentSteppingResolver();
+        currentSteppingResolver?.();
         if (!this._isRunning) {
             this._startBenchmark();
             this._showSection("#running");
@@ -55,8 +54,7 @@ class MainBenchmarkClient {
         const currentSteppingResolver = this._steppingResolver;
         this._steppingPromise = null;
         this._steppingResolver = null;
-        if (currentSteppingResolver)
-            currentSteppingResolver();
+        currentSteppingResolver?.();
     }
 
     async _awaitNextStep(suite, test) {


### PR DESCRIPTION
- Use the temp currentSteppingResolver varialbe in places we modiify the _steppingResolver to avoid 
  acessing the oudated version
- Add an explicti "Finished" step so we can inspect the final state of a workload instead of jumping directly to the setup of the next one