### PR TITLE
fix: correct operator precedence in stepRunnerType resolution

### DIFF
--- a/resources/suite-runner.mjs
+++ b/resources/suite-runner.mjs
@@ -77,7 +77,7 @@ export class SuiteRunner {
             if (this.#client?.willRunTest)
                 await this.#client.willRunTest(this.#suite, step);
 
-            const stepRunnerType = this.#suite.type ?? this.params.useAsyncSteps ? "async" : "default";
+            const stepRunnerType = this.#suite.type ?? (this.params.useAsyncSteps ? "async" : "default");
             const stepRunnerClass = STEP_RUNNER_LOOKUP[stepRunnerType];
             const stepRunner = new stepRunnerClass(this.#frame, this.#page, this.#params, this.#suite, step, this._recordTestResults, stepRunnerType);
             await stepRunner.runStep();


### PR DESCRIPTION
The stepRunnerType resolution in SuiteRunner._runSuite incorrectly evaluated this.#suite.type due to operator precedence when this.#suite.type was truthy (e.g., "remote"). Specifically, the ternary operator ? : was incorrectly associated with the ?? operator, leading to scenarios where a specific suite type was overridden by the async/default logic. The expression was refactored to explicitly parenthesize the default logic, ensuring this.#suite.type is correctly prioritized.