### PR TITLE
Implement Params.prototype.isDefault() helper

### DIFF
--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -306,7 +306,7 @@ class MainBenchmarkClient {
     }
 
     _populateNonStandardParams() {
-        if (params === defaultParams)
+        if (params.isDefault())
             return;
         const paramsDiff = [];
         const usedSearchparams = params.toSearchParamsObject();

--- a/resources/shared/params.mjs
+++ b/resources/shared/params.mjs
@@ -205,6 +205,10 @@ export class Params {
     toSearchParams() {
         return this.toSearchParamsObject().toString();
     }
+
+    isDefault() {
+        return this === defaultParams;
+    }
 }
 
 function isValidJsonUrl(url) {

--- a/tests/unittests/params.mjs
+++ b/tests/unittests/params.mjs
@@ -75,6 +75,23 @@ describe("Params", () => {
             expect(params.toSearchParams()).to.equal("suites=");
         });
     });
+    describe("isDefault", () => {
+        it("should return true for defaultParams", () => {
+            expect(defaultParams.isDefault()).to.be(true);
+        });
+        it("should return false for newly instantiated empty Params", () => {
+            const params = new Params();
+            expect(params.isDefault()).to.be(false);
+        });
+        it("should return false for custom params", () => {
+            const params = new Params(
+                new URLSearchParams({
+                    iterationCount: "100",
+                })
+            );
+            expect(params.isDefault()).to.be(false);
+        });
+    });
 
     describe("parse input params", () => {
         it("should parse custom viewport", () => {


### PR DESCRIPTION
The isDefault getter is a bit more explict than checking for equalirty against defaultParams.