### PR TITLE
Bind dev server to IPv4 address

### DIFF
--- a/tests/server.mjs
+++ b/tests/server.mjs
@@ -16,6 +16,7 @@ export default async function serve(port) {
         throw new Error("Port is required");
     const ws = await LocalWebServer.create({
         port: port,
+        hostname: "127.0.0.1",
         directory: ROOT_DIR,
         corsOpenerPolicy: "same-origin",
         corsEmbedderPolicy: "require-corp",


### PR DESCRIPTION
Using "localhost' can cause some issues on certain OS / browser combination where we end up binding to the IPv6 address instead of IPv4 and the browser uses the other version for resolving "localhost". Forcing IPv4 for the test server seems to resolve this.