### PR TITLE
Add --cache option for npm run dev server

### DIFF
--- a/tests/helper.mjs
+++ b/tests/helper.mjs
@@ -1,6 +1,6 @@
 import commandLineUsage from "command-line-usage";
 import commandLineArgs from "command-line-args";
-import serve from "./server.mjs";
+import serve, { DEFAULT_CACHE_DURATION } from "./server.mjs";
 
 import firefox from "selenium-webdriver/firefox.js";
 import chrome from "selenium-webdriver/chrome.js";
@@ -73,9 +73,8 @@ export default async function testSetup(helpText) {
         }
     }
     const PORT = options.port;
-    const CACHE_DURATION = 3600;
 
-    const server = await serve(PORT, CACHE_DURATION);
+    const server = await serve(PORT, DEFAULT_CACHE_DURATION);
     let driver, logInspector;
 
     process.on("unhandledRejection", (err) => {

--- a/tests/helper.mjs
+++ b/tests/helper.mjs
@@ -73,7 +73,9 @@ export default async function testSetup(helpText) {
         }
     }
     const PORT = options.port;
-    const server = await serve(PORT);
+    const CACHE_DURATION = 3600;
+
+    const server = await serve(PORT, CACHE_DURATION);
     let driver, logInspector;
 
     process.on("unhandledRejection", (err) => {

--- a/tests/server.mjs
+++ b/tests/server.mjs
@@ -11,9 +11,23 @@ import "lws-static";
 
 const ROOT_DIR = path.join(process.cwd(), "./");
 
-export default async function serve(port) {
+class CacheControlPlugin {
+    middleware(config) {
+        return async (ctx, next) => {
+            ctx.set("Cache-Control", `max-age=${config.cache}`);
+            await next();
+        };
+    }
+}
+
+export default async function serve(port, cacheDuration) {
     if (!port)
         throw new Error("Port is required");
+
+    const stack = ["lws-log", "lws-cors", "lws-static", "lws-index"];
+    if (cacheDuration !== undefined)
+        stack.unshift(CacheControlPlugin);
+
     const ws = await LocalWebServer.create({
         port: port,
         hostname: "127.0.0.1",
@@ -21,7 +35,8 @@ export default async function serve(port) {
         corsOpenerPolicy: "same-origin",
         corsEmbedderPolicy: "require-corp",
         logFormat: "dev",
-        stack: ["lws-log", "lws-cors", "lws-static", "lws-index"],
+        stack,
+        cache: cacheDuration,
     });
     await verifyStartup(ws, port);
 
@@ -51,9 +66,16 @@ async function verifyStartup(ws, port) {
 }
 
 function main() {
-    const optionDefinitions = [{ name: "port", type: Number, defaultValue: 8080, description: "Set the test-server port, The default value is 8080." }];
+    const optionDefinitions = [
+        { name: "port", type: Number, defaultValue: 8080, description: "Set the test-server port, The default value is 8080." },
+        { name: "cache", type: Number, description: "Set the cache duration in seconds. If flag is present without a value, defaults to 3600." },
+    ];
     const options = commandLineArgs(optionDefinitions);
-    serve(options.port);
+    let cacheDuration = undefined;
+    if ("cache" in options)
+        cacheDuration = options.cache ?? 3600;
+
+    serve(options.port, cacheDuration);
 }
 
 if (esMain(import.meta))

--- a/tests/server.mjs
+++ b/tests/server.mjs
@@ -10,6 +10,7 @@ import "lws-log";
 import "lws-static";
 
 const ROOT_DIR = path.join(process.cwd(), "./");
+export const DEFAULT_CACHE_DURATION = 3600;
 
 class CacheControlPlugin {
     middleware(config) {
@@ -68,12 +69,12 @@ async function verifyStartup(ws, port) {
 function main() {
     const optionDefinitions = [
         { name: "port", type: Number, defaultValue: 8080, description: "Set the test-server port, The default value is 8080." },
-        { name: "cache", type: Number, description: "Set the cache duration in seconds. If flag is present without a value, defaults to 3600." },
+        { name: "cache", type: Number, description: `Set the cache duration in seconds. If flag is present without a value, defaults to ${DEFAULT_CACHE_DURATION}.` },
     ];
     const options = commandLineArgs(optionDefinitions);
     let cacheDuration = undefined;
     if ("cache" in options)
-        cacheDuration = options.cache ?? 3600;
+        cacheDuration = options.cache ?? DEFAULT_CACHE_DURATION;
 
     serve(options.port, cacheDuration);
 }


### PR DESCRIPTION
- --cache without args uses cache-control 3600 header
- --cache=DURATION for explcit cache duration
- use --cache for test server to speed up runs a bit