### PR TITLE
Fix DeveloperMenu z-index

### DIFF
--- a/resources/main.css
+++ b/resources/main.css
@@ -235,6 +235,7 @@ button,
     background: #602525;
     border: 3px solid rgba(255, 255, 255, 0.5);
     position: fixed;
+    z-index: 9999;
     left: 10px;
     top: 10px;
     max-height: calc(100vh - 20px);


### PR DESCRIPTION
The button unification PR accidentally raised the button bar above the developer menu.
Adjusting the z-index fixes this.