### PR TITLE
Track Responsive-Design carousel resize events

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -163,6 +163,46 @@ class PageElement {
         this.#node.scrollIntoView(options);
     }
 
+    observeResizeEvents() {
+        const contentWindow = this.#node.ownerDocument.defaultView;
+        const state = {
+            count: 0,
+            lastWidth: null,
+        };
+        let markReady;
+        // Resolves on the first delivery so callers can seed a baseline before resizing.
+        const ready = new Promise((resolve) => {
+            markReady = resolve;
+        });
+        const observer = new contentWindow.ResizeObserver((entries) => {
+            for (const entry of entries) {
+                const contentBoxSize = entry.contentBoxSize;
+                const inlineSize = Array.isArray(contentBoxSize) ? contentBoxSize[0]?.inlineSize : contentBoxSize?.inlineSize;
+                const width = inlineSize ?? entry.contentRect.width;
+                // The first delivery seeds the baseline width without counting it as a change.
+                if (state.lastWidth === null) {
+                    state.lastWidth = width;
+                    markReady();
+                    continue;
+                }
+                if (width === state.lastWidth)
+                    continue;
+                state.count++;
+                state.lastWidth = width;
+            }
+        });
+        observer.observe(this.#node);
+        return {
+            ready,
+            get count() {
+                return state.count;
+            },
+            disconnect() {
+                observer.disconnect();
+            },
+        };
+    }
+
     dispatchEvent(eventName, options = NATIVE_OPTIONS, eventType = Event) {
         if (eventName === "submit")
             // FIXME FireFox doesn't like `new Event('submit')

--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -163,14 +163,14 @@ class PageElement {
         this.#node.scrollIntoView(options);
     }
 
-    observeResizeEvents() {
+    async observeResizeEvents() {
         const contentWindow = this.#node.ownerDocument.defaultView;
         const state = {
             count: 0,
             lastWidth: null,
         };
         let markReady;
-        // Resolves on the first delivery so callers can seed a baseline before resizing.
+        // Resolves on the first callback so the initial width can be used as a baseline.
         const ready = new Promise((resolve) => {
             markReady = resolve;
         });
@@ -179,7 +179,7 @@ class PageElement {
                 const contentBoxSize = entry.contentBoxSize;
                 const inlineSize = Array.isArray(contentBoxSize) ? contentBoxSize[0]?.inlineSize : contentBoxSize?.inlineSize;
                 const width = inlineSize ?? entry.contentRect.width;
-                // The first delivery seeds the baseline width without counting it as a change.
+                // The first callback seeds the baseline width without counting it as a change.
                 if (state.lastWidth === null) {
                     state.lastWidth = width;
                     markReady();
@@ -192,13 +192,11 @@ class PageElement {
             }
         });
         observer.observe(this.#node);
+        await ready;
         return {
-            ready,
-            get count() {
-                return state.count;
-            },
-            disconnect() {
+            stop() {
                 observer.disconnect();
+                return state.count;
             },
         };
     }

--- a/suites-experimental/suites.mjs
+++ b/suites-experimental/suites.mjs
@@ -214,6 +214,9 @@ export const ExperimentalSuites = freezeSuites([
             new BenchmarkTestStep("ReduceWidthIn5Steps", async (page) => {
                 const widths = [768, 704, 640, 560, 480];
                 const MATCH_MEDIA_QUERY_BREAKPOINT = 640;
+                const carouselResizeObservations = page.querySelector(".carousel", ["cooking-app", "main-content", "recipe-carousel"]).observeResizeEvents();
+                // Seed the baseline width before the synchronous width changes below.
+                await carouselResizeObservations.ready;
 
                 // The matchMedia query is "(max-width: 640px)"
                 // Starting from a width > 640px, we'll only get 1 event when crossing to <= 640px
@@ -230,6 +233,12 @@ export const ExperimentalSuites = freezeSuites([
                 }
 
                 await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+                const { count } = carouselResizeObservations;
+                carouselResizeObservations.disconnect();
+                if (count)
+                    console.warn(`ReduceWidthIn5Steps: recipe-carousel ResizeObserver delivered ${count} coalesced width change(s).`);
+                else
+                    console.warn("ReduceWidthIn5Steps: recipe-carousel ResizeObserver delivered 0 width changes; expected width changes during iframe resize.");
             }),
             new BenchmarkTestStep("ScrollToChatAndSendMessages", async (page) => {
                 const cvWorkComplete = new Promise((resolve) => {
@@ -273,6 +282,9 @@ export const ExperimentalSuites = freezeSuites([
             new BenchmarkTestStep("IncreaseWidthIn5Steps", async (page) => {
                 const widths = [560, 640, 704, 768, 800];
                 const MATCH_MEDIA_QUERY_BREAKPOINT = 704;
+                const carouselResizeObservations = page.querySelector(".carousel", ["cooking-app", "main-content", "recipe-carousel"]).observeResizeEvents();
+                // Seed the baseline width before the synchronous width changes below.
+                await carouselResizeObservations.ready;
 
                 // The matchMedia query is "(max-width: 640px)"
                 // Starting from a width <= 640px, we'll get 1 event when crossing back to > 640px.
@@ -289,6 +301,12 @@ export const ExperimentalSuites = freezeSuites([
                 }
 
                 await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+                const { count } = carouselResizeObservations;
+                carouselResizeObservations.disconnect();
+                if (count)
+                    console.warn(`IncreaseWidthIn5Steps: recipe-carousel ResizeObserver delivered ${count} coalesced width change(s).`);
+                else
+                    console.warn("IncreaseWidthIn5Steps: recipe-carousel ResizeObserver delivered 0 width changes; expected width changes during iframe resize.");
             }),
         ],
     },

--- a/suites-experimental/suites.mjs
+++ b/suites-experimental/suites.mjs
@@ -3,6 +3,14 @@ import { getTodoText } from "../resources/shared/translations.mjs";
 import { getNumberOfItemsToAdd } from "../resources/shared/todomvc-utils.mjs";
 import { freezeSuites } from "../resources/suites-helper.mjs";
 
+function reportRecipeCarouselResizeEvents(stepName, resizeEvents) {
+    const count = resizeEvents.stop();
+    if (count)
+        console.warn(`${stepName}: recipe-carousel ResizeObserver reported ${count} width change(s).`);
+    else
+        console.warn(`${stepName}: recipe-carousel ResizeObserver reported 0 width changes; expected width changes during iframe resize.`);
+}
+
 export const ExperimentalSuites = freezeSuites([
     {
         name: "TodoMVC-LocalStorage",
@@ -214,9 +222,7 @@ export const ExperimentalSuites = freezeSuites([
             new BenchmarkTestStep("ReduceWidthIn5Steps", async (page) => {
                 const widths = [768, 704, 640, 560, 480];
                 const MATCH_MEDIA_QUERY_BREAKPOINT = 640;
-                const carouselResizeObservations = page.querySelector(".carousel", ["cooking-app", "main-content", "recipe-carousel"]).observeResizeEvents();
-                // Seed the baseline width before the synchronous width changes below.
-                await carouselResizeObservations.ready;
+                const carouselResizeEvents = await page.querySelector(".carousel", ["cooking-app", "main-content", "recipe-carousel"]).observeResizeEvents();
 
                 // The matchMedia query is "(max-width: 640px)"
                 // Starting from a width > 640px, we'll only get 1 event when crossing to <= 640px
@@ -233,12 +239,7 @@ export const ExperimentalSuites = freezeSuites([
                 }
 
                 await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
-                const { count } = carouselResizeObservations;
-                carouselResizeObservations.disconnect();
-                if (count)
-                    console.warn(`ReduceWidthIn5Steps: recipe-carousel ResizeObserver delivered ${count} coalesced width change(s).`);
-                else
-                    console.warn("ReduceWidthIn5Steps: recipe-carousel ResizeObserver delivered 0 width changes; expected width changes during iframe resize.");
+                reportRecipeCarouselResizeEvents("ReduceWidthIn5Steps", carouselResizeEvents);
             }),
             new BenchmarkTestStep("ScrollToChatAndSendMessages", async (page) => {
                 const cvWorkComplete = new Promise((resolve) => {
@@ -282,9 +283,7 @@ export const ExperimentalSuites = freezeSuites([
             new BenchmarkTestStep("IncreaseWidthIn5Steps", async (page) => {
                 const widths = [560, 640, 704, 768, 800];
                 const MATCH_MEDIA_QUERY_BREAKPOINT = 704;
-                const carouselResizeObservations = page.querySelector(".carousel", ["cooking-app", "main-content", "recipe-carousel"]).observeResizeEvents();
-                // Seed the baseline width before the synchronous width changes below.
-                await carouselResizeObservations.ready;
+                const carouselResizeEvents = await page.querySelector(".carousel", ["cooking-app", "main-content", "recipe-carousel"]).observeResizeEvents();
 
                 // The matchMedia query is "(max-width: 640px)"
                 // Starting from a width <= 640px, we'll get 1 event when crossing back to > 640px.
@@ -301,12 +300,7 @@ export const ExperimentalSuites = freezeSuites([
                 }
 
                 await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
-                const { count } = carouselResizeObservations;
-                carouselResizeObservations.disconnect();
-                if (count)
-                    console.warn(`IncreaseWidthIn5Steps: recipe-carousel ResizeObserver delivered ${count} coalesced width change(s).`);
-                else
-                    console.warn("IncreaseWidthIn5Steps: recipe-carousel ResizeObserver delivered 0 width changes; expected width changes during iframe resize.");
+                reportRecipeCarouselResizeEvents("IncreaseWidthIn5Steps", carouselResizeEvents);
             }),
         ],
     },

--- a/tests/unittests/benchmark-runner.mjs
+++ b/tests/unittests/benchmark-runner.mjs
@@ -307,3 +307,86 @@ describe("BenchmarkRunner", () => {
         });
     });
 });
+
+describe("PageElement", () => {
+    describe("observeResizeEvents", () => {
+        before(function () {
+            skipInShell(this);
+        });
+
+        async function withPageElement(configureFrame, callback) {
+            let fixtureNode;
+            let result;
+            const runner = new BenchmarkRunner(
+                [
+                    {
+                        name: "PageElement fixture",
+                        enabled: true,
+                        url: "about:blank",
+                        async prepare(page) {
+                            result = await callback(page.getElementById("resize-target"), fixtureNode);
+                        },
+                        tests: [],
+                    },
+                ],
+                {}
+            );
+            sinon.stub(SuiteRunner.prototype, "_loadFrame").callsFake(async function () {
+                fixtureNode = configureFrame(this.frame);
+            });
+            sinon.stub(SuiteRunner.prototype, "_runSuite").callsFake(async () => {});
+            await runner.runAllSuites();
+            return result;
+        }
+
+        // A fake ResizeObserver drives deliveries synchronously for exact-count assertions.
+        async function createTracker() {
+            let deliver;
+            class FakeResizeObserver {
+                constructor(callback) {
+                    deliver = (...widths) => callback(widths.map((width) => ({ contentBoxSize: [{ inlineSize: width }] })));
+                }
+                observe() {}
+                disconnect() {}
+            }
+            return withPageElement(
+                (frame) => {
+                    Object.defineProperty(frame.contentWindow, "ResizeObserver", { configurable: true, value: FakeResizeObserver });
+                    const node = frame.contentDocument.createElement("div");
+                    node.id = "resize-target";
+                    frame.contentDocument.body.appendChild(node);
+                    return node;
+                },
+                (element) => ({
+                    resizeEvents: element.observeResizeEvents(),
+                    deliver: (...widths) => deliver(...widths),
+                })
+            );
+        }
+
+        it("treats the first delivery as the baseline without counting it", async () => {
+            const { resizeEvents, deliver } = await createTracker();
+            deliver(200);
+            await resizeEvents.ready;
+            expect(resizeEvents.count).to.equal(0);
+        });
+
+        it("counts each distinct width change exactly once", async () => {
+            const { resizeEvents, deliver } = await createTracker();
+            deliver(200); // seed
+            deliver(300);
+            deliver(400);
+            deliver(500);
+            expect(resizeEvents.count).to.equal(3);
+        });
+
+        it("does not count deliveries that report the same width", async () => {
+            const { resizeEvents, deliver } = await createTracker();
+            deliver(200); // seed
+            deliver(300);
+            deliver(300);
+            deliver(300);
+            expect(resizeEvents.count).to.equal(1);
+        });
+    });
+});

--- a/tests/unittests/benchmark-runner.mjs
+++ b/tests/unittests/benchmark-runner.mjs
@@ -339,7 +339,7 @@ describe("PageElement", () => {
             return result;
         }
 
-        // A fake ResizeObserver drives deliveries synchronously for exact-count assertions.
+        // A fake ResizeObserver drives callbacks synchronously for exact-count assertions.
         async function createTracker() {
             let deliver;
             const disconnect = sinon.stub();
@@ -368,7 +368,7 @@ describe("PageElement", () => {
             );
         }
 
-        it("treats the first delivery as the baseline without counting it", async () => {
+        it("treats the first callback as the baseline without counting it", async () => {
             const { resizeEventsPromise, deliver, disconnect } = await createTracker();
             deliver(200);
             const resizeEvents = await resizeEventsPromise;
@@ -386,7 +386,7 @@ describe("PageElement", () => {
             expect(resizeEvents.stop()).to.equal(3);
         });
 
-        it("does not count deliveries that report the same width", async () => {
+        it("does not count callbacks that report the same width", async () => {
             const { resizeEventsPromise, deliver } = await createTracker();
             deliver(200); // seed
             const resizeEvents = await resizeEventsPromise;

--- a/tests/unittests/benchmark-runner.mjs
+++ b/tests/unittests/benchmark-runner.mjs
@@ -342,12 +342,15 @@ describe("PageElement", () => {
         // A fake ResizeObserver drives deliveries synchronously for exact-count assertions.
         async function createTracker() {
             let deliver;
+            const disconnect = sinon.stub();
             class FakeResizeObserver {
                 constructor(callback) {
                     deliver = (...widths) => callback(widths.map((width) => ({ contentBoxSize: [{ inlineSize: width }] })));
                 }
                 observe() {}
-                disconnect() {}
+                disconnect() {
+                    disconnect();
+                }
             }
             return withPageElement(
                 (frame) => {
@@ -358,35 +361,39 @@ describe("PageElement", () => {
                     return node;
                 },
                 (element) => ({
-                    resizeEvents: element.observeResizeEvents(),
+                    resizeEventsPromise: element.observeResizeEvents(),
                     deliver: (...widths) => deliver(...widths),
+                    disconnect,
                 })
             );
         }
 
         it("treats the first delivery as the baseline without counting it", async () => {
-            const { resizeEvents, deliver } = await createTracker();
+            const { resizeEventsPromise, deliver, disconnect } = await createTracker();
             deliver(200);
-            await resizeEvents.ready;
-            expect(resizeEvents.count).to.equal(0);
+            const resizeEvents = await resizeEventsPromise;
+            expect(resizeEvents.stop()).to.equal(0);
+            sinon.assert.calledOnce(disconnect);
         });
 
         it("counts each distinct width change exactly once", async () => {
-            const { resizeEvents, deliver } = await createTracker();
+            const { resizeEventsPromise, deliver } = await createTracker();
             deliver(200); // seed
+            const resizeEvents = await resizeEventsPromise;
             deliver(300);
             deliver(400);
             deliver(500);
-            expect(resizeEvents.count).to.equal(3);
+            expect(resizeEvents.stop()).to.equal(3);
         });
 
         it("does not count deliveries that report the same width", async () => {
-            const { resizeEvents, deliver } = await createTracker();
+            const { resizeEventsPromise, deliver } = await createTracker();
             deliver(200); // seed
+            const resizeEvents = await resizeEventsPromise;
             deliver(300);
             deliver(300);
             deliver(300);
-            expect(resizeEvents.count).to.equal(1);
+            expect(resizeEvents.stop()).to.equal(1);
         });
     });
 });


### PR DESCRIPTION
Follow-up to the review feedback on #453, which asked to track the number of resize events so we can verify consistency across browsers.

- Add PageElement.observeResizeEvents() to count distinct content-box width changes delivered by ResizeObserver. The first delivery seeds the baseline and is not counted, and repeated deliveries of the same width are ignored.
- Observe the recipe carousel during ReduceWidthIn5Steps and IncreaseWidthIn5Steps, and log the observed count so the numbers can be compared across browsers.
- Add unittests covering baseline seeding, distinct width changes, and duplicate-width deliveries.