### PR TITLE
Avoid function state in IndexedDB page wait

### DIFF
--- a/suites-experimental/javascript-wc-indexeddb/dist/src/workload-test.mjs
+++ b/suites-experimental/javascript-wc-indexeddb/dist/src/workload-test.mjs
@@ -22,6 +22,12 @@ const deletePromise = new Promise((resolve) => {
     window.addEventListener(promisesEventsNames.delete, () => resolve());
 });
 
+function waitForPreviousPageLoaded() {
+    return new Promise((resolve) => {
+        window.addEventListener("previous-page-loaded", resolve, { once: true });
+    });
+}
+
 const suites = {
     default: new BenchmarkSuite("indexeddb", [
         new BenchmarkStep(`Adding${numberOfItemsToAdd}Items`, async () => {
@@ -65,14 +71,7 @@ const suites = {
         new BenchmarkStep("DeletingAllItems", async () => {
             const numberOfItemsPerIteration = 10;
             const numberOfIterations = 10;
-            function iterationFinishedListener() {
-                iterationFinishedListener.promiseResolve();
-            }
-            window.addEventListener("previous-page-loaded", iterationFinishedListener);
             for (let j = 0; j < numberOfIterations; j++) {
-                const iterationFinishedPromise = new Promise((resolve) => {
-                    iterationFinishedListener.promiseResolve = resolve;
-                });
                 const todoList = document.querySelector("todo-app").shadowRoot.querySelector("todo-list");
                 const items = todoList.shadowRoot.querySelectorAll("todo-item");
                 for (let i = numberOfItemsPerIteration - 1; i >= 0; i--) {
@@ -81,8 +80,9 @@ const suites = {
                 }
                 if (j < 9) {
                     const previousPageButton = document.querySelector("todo-app").shadowRoot.querySelector("todo-bottombar").shadowRoot.querySelector(".previous-page-button");
+                    const previousPageLoadedPromise = waitForPreviousPageLoaded();
                     previousPageButton.click();
-                    await iterationFinishedPromise;
+                    await previousPageLoadedPromise;
                 }
             }
         }),

--- a/suites-experimental/javascript-wc-indexeddb/src/workload-test.mjs
+++ b/suites-experimental/javascript-wc-indexeddb/src/workload-test.mjs
@@ -22,6 +22,12 @@ const deletePromise = new Promise((resolve) => {
     window.addEventListener(promisesEventsNames.delete, () => resolve());
 });
 
+function waitForPreviousPageLoaded() {
+    return new Promise((resolve) => {
+        window.addEventListener("previous-page-loaded", resolve, { once: true });
+    });
+}
+
 const suites = {
     default: new BenchmarkSuite("indexeddb", [
         new BenchmarkStep(`Adding${numberOfItemsToAdd}Items`, async () => {
@@ -65,14 +71,7 @@ const suites = {
         new BenchmarkStep("DeletingAllItems", async () => {
             const numberOfItemsPerIteration = 10;
             const numberOfIterations = 10;
-            function iterationFinishedListener() {
-                iterationFinishedListener.promiseResolve();
-            }
-            window.addEventListener("previous-page-loaded", iterationFinishedListener);
             for (let j = 0; j < numberOfIterations; j++) {
-                const iterationFinishedPromise = new Promise((resolve) => {
-                    iterationFinishedListener.promiseResolve = resolve;
-                });
                 const todoList = document.querySelector("todo-app").shadowRoot.querySelector("todo-list");
                 const items = todoList.shadowRoot.querySelectorAll("todo-item");
                 for (let i = numberOfItemsPerIteration - 1; i >= 0; i--) {
@@ -81,8 +80,9 @@ const suites = {
                 }
                 if (j < 9) {
                     const previousPageButton = document.querySelector("todo-app").shadowRoot.querySelector("todo-bottombar").shadowRoot.querySelector(".previous-page-button");
+                    const previousPageLoadedPromise = waitForPreviousPageLoaded();
                     previousPageButton.click();
-                    await iterationFinishedPromise;
+                    await previousPageLoadedPromise;
                 }
             }
         }),


### PR DESCRIPTION
Follow-up to the review on #531.

`DeletingAllItems` stored its resolver as a property on the
`iterationFinishedListener` function object and registered a
`previous-page-loaded` listener that was never removed.

This replaces that with a `waitForPreviousPageLoaded()` helper which
registers a one-shot listener per page transition, so the resolver is
local to the navigation it belongs to and the listener cleans itself up.