### PR TITLE
Remove Safari scrollIntoView fallback from Responsive-Design

### DIFF
--- a/suites-experimental/suites.mjs
+++ b/suites-experimental/suites.mjs
@@ -264,11 +264,7 @@ export const ExperimentalSuites = freezeSuites([
                     page.layout();
                 }
 
-                // Safari can overscroll the chat element here and never send the
-                // video grid's contentvisibilityautostatechange event. See
-                // https://github.com/WebKit/Speedometer/issues/525. Remove this
-                // fallback once Speedometer CI runs a Safari with that WebKit fix.
-                await Promise.race([cvWorkComplete, new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))]);
+                await cvWorkComplete;
             }),
             new BenchmarkTestStep("IncreaseWidthIn5Steps", async (page) => {
                 const widths = [560, 640, 704, 768, 800];


### PR DESCRIPTION
ScrollToChatAndSendMessages raced the video grid's content-visibility event against a two-frame timeout, because Safari could overscroll the chat element and never fire it (#525).

The underlying WebKit bug no longer reproduces, and CI now runs Safari 26.4, so the fallback is no longer needed.

Wait for the event directly instead.