### PR TITLE
Fix the warmup suite, which has not run since the SuiteRunner refactor

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -239,7 +239,13 @@ function geomeanToScore(geomean) {
 // compilation of runner methods in the middle of the measuring cycle.
 export const WarmupSuite = {
     name: "Warmup",
-    url: "warmup/index.html",
+    // _loadFrame() resolves suite URLs against the document base, so this needs the same
+    // root-relative form as the regular suites. It was still the 3.1-era path, which
+    // _prepareSuite() used to prefix with "resources/".
+    url: "suites/warmup/index.html",
+    // runAllSuites() skips suites that are not enabled. Unlike the regular suites, the warmup
+    // suite is not passed through BenchmarkConfigurator, so nothing else sets this for it.
+    enabled: true,
     async prepare(page) {
         await page.waitForElement("#testItem");
     },

--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -1,4 +1,4 @@
-import { BenchmarkRunner } from "./benchmark-runner.mjs";
+import { BenchmarkRunner, WarmupSuite } from "./benchmark-runner.mjs";
 import * as Statistics from "./statistics.mjs";
 import { renderMetricView } from "./metric-ui.mjs";
 import { defaultParams, params } from "./shared/params.mjs";
@@ -149,6 +149,9 @@ class MainBenchmarkClient {
     }
 
     async didFinishSuite(suite) {
+        // The warmup suite is not part of stepCount, so counting it would overshoot the bar.
+        if (suite === WarmupSuite)
+            return;
         this._finishedTestCount++;
         this._progressCompleted.value = this._finishedTestCount;
         if (this._steppingPromise)

--- a/resources/suite-runner.mjs
+++ b/resources/suite-runner.mjs
@@ -101,6 +101,9 @@ export class SuiteRunner {
     }
 
     _validateSuiteResults() {
+        // The warmup suite's results are intentionally not recorded, so it has no total.
+        if (this.#suite === WarmupSuite)
+            return;
         // When the test is fast and the precision is low (for example with Firefox'
         // privacy.resistFingerprinting preference), it's possible that the measured
         // total duration for an entire is 0.

--- a/resources/suite-runner.mjs
+++ b/resources/suite-runner.mjs
@@ -19,10 +19,16 @@ export class SuiteRunner {
 
     constructor(frame, page, params, suite, client, measuredValues) {
         // FIXME: Create SuiteRunner-local measuredValues.
-        this.#suiteResults = measuredValues.tests[suite.name];
-        if (!this.#suiteResults) {
+        if (suite === WarmupSuite) {
+            // The warmup suite's results are intentionally not reported. Registering them in
+            // measuredValues would leave a 0-total entry, which zeroes the overall geomean.
             this.#suiteResults = { tests: {}, prepare: 0, total: 0 };
-            measuredValues.tests[suite.name] = this.#suiteResults;
+        } else {
+            this.#suiteResults = measuredValues.tests[suite.name];
+            if (!this.#suiteResults) {
+                this.#suiteResults = { tests: {}, prepare: 0, total: 0 };
+                measuredValues.tests[suite.name] = this.#suiteResults;
+            }
         }
         this.#frame = frame;
         this.#page = page;


### PR DESCRIPTION
Fixes #584.

Enabling `useWarmupSuite` has had no effect on `main` since the `SuiteRunner` refactor. Reviving it turned up four independent defects, each only reachable once the previous one is fixed — which is likely why they went unnoticed.

**1. The warmup suite is never run.** `runAllSuites()` skips any suite without an `enabled` flag, and `WarmupSuite` does not define one — that flag is only set by `BenchmarkConfigurator` on the regular suites. So `useWarmupSuite` is currently a silent no-op.

**2. Its `url` is stale.** `_loadFrame()` resolves suite URLs against the document base, but `WarmupSuite.url` was still the 3.1-era `warmup/index.html`, which `_prepareSuite()` used to prefix with `resources/`. The file now lives at `suites/warmup/index.html`, so the frame 404s.

**3. Its results zero the score.** The `SuiteRunner` constructor eagerly registers `measuredValues.tests[suite.name]`, including for the warmup suite. Because `_recordTestResults()` intentionally skips warmup, that entry keeps `total: 0`, and the geomean loop does `product *= suiteTotal` over every entry — so the geomean becomes `0` and the score `Infinity`. In 3.1 the entry was created lazily inside `_recordTestResults()`, so it never existed. This is the most serious of the four: it produces a wrong score rather than failing loudly.

**4. Validation throws on the zero total.** `_validateSuiteResults()` is called for every suite and throws when the total is `0`, which the warmup suite's always is. Guarding inside the method covers both call sites (`SuiteRunner._runSuite` and `RemoteSuiteRunner`).

Plus one UI fix: the warmup suite is not counted in `stepCount`, so `didFinishSuite()` would push the progress bar past its maximum.

### Verification

Run `?developerMode&useWarmupSuite&suites=TodoMVC-JavaScript-ES5&iterationCount=2`:

- before: `useWarmupSuite` is accepted but no warmup runs
- after each fix in turn: 404 on the warmup frame, then `Geomean 0.00` with an `Infinity` score, then a clean run
- with all four: the warmup suite loads and runs, and the geomean equals the single suite's total (87.65 in my run), confirming warmup stays out of the aggregate

Happy to split this into separate commits or drop the progress-bar change if you would prefer a narrower diff.
