### PR TITLE
Fix benchmark startup sequence for testing

### DIFF
--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -26,16 +26,17 @@ class MainBenchmarkClient {
     _steppingPromise = null;
     _steppingResolver = null;
     _benchmarkConfiguratorPromise = null;
+    _isInitialized = false;
+
+    get isInitialized() {
+        return this._isInitialized;
+    }
 
     constructor() {
         this._benchmarkConfiguratorPromise = import("./benchmark-configurator.mjs");
         this.prepareUI();
         this.evaluateParams();
         this._showSection(window.location.hash);
-
-        this._benchmarkConfiguratorPromise.then(() => {
-            window.dispatchEvent(new Event("SpeedometerReady"));
-        });
     }
 
     isRunning() {
@@ -393,6 +394,9 @@ class MainBenchmarkClient {
             this.start();
         else
             this._setBenchmarkState(BENCHMARK_STATE.READY);
+
+        this._isInitialized = true;
+        window.dispatchEvent(new Event("SpeedometerReady"));
     }
 
     async _setBenchmarkState(state) {

--- a/resources/main.mjs
+++ b/resources/main.mjs
@@ -390,13 +390,14 @@ class MainBenchmarkClient {
             document.body.append(this._developerModeContainer);
         }
 
-        if (params.startAutomatically)
-            this.start();
-        else
+        if (!params.startAutomatically)
             this._setBenchmarkState(BENCHMARK_STATE.READY);
 
         this._isInitialized = true;
         window.dispatchEvent(new Event("SpeedometerReady"));
+
+        if (params.startAutomatically)
+            this.start();
     }
 
     async _setBenchmarkState(state) {

--- a/tests/run-end2end.mjs
+++ b/tests/run-end2end.mjs
@@ -18,7 +18,7 @@ async function testPage(url) {
     await driver.get(`http://localhost:${port}/${url}`);
 
     await driver.executeAsyncScript((callback) => {
-        if (globalThis.benchmarkClient)
+        if (globalThis.benchmarkClient.isInitialized)
             callback();
         else
             globalThis.addEventListener("SpeedometerReady", () => callback(), { once: true });


### PR DESCRIPTION
There could be a race condition between sending the SpeedometerReady and and the testing running installing the event handler. This PR delays sending the SpeedometerReady event to a later async point in the `evaluateParams` method..